### PR TITLE
Rename namespaces to easynav

### DIFF
--- a/easynav_common/include/easynav_common/Configuration.hpp
+++ b/easynav_common/include/easynav_common/Configuration.hpp
@@ -20,15 +20,15 @@
 /// \file
 /// \brief Definition of the ConfigurationValue class used to store multiple types of configuration data.
 
-#ifndef EASYNAV_CORE__CONFIGURATION_HPP_
-#define EASYNAV_CORE__CONFIGURATION_HPP_
+#ifndef EASYNAV_COMMON__CONFIGURATION_HPP_
+#define EASYNAV_COMMON__CONFIGURATION_HPP_
 
 #include <string>
 #include <vector>
 #include <variant>
 #include <stdexcept>
 
-namespace easynav_common
+namespace easynav
 {
 
 /**
@@ -118,6 +118,6 @@ private:
   ValueType value_;
 };
 
-}  // namespace easynav_common
+}  // namespace easynav
 
-#endif  // EASYNAV_CORE__CONFIGURATION_HPP_
+#endif  // EASYNAV_COMMON__CONFIGURATION_HPP_

--- a/easynav_common/include/easynav_common/Result.hpp
+++ b/easynav_common/include/easynav_common/Result.hpp
@@ -20,14 +20,14 @@
 /// \file
 /// \brief Definition of the Result class, a generic outcome container inspired by Rust's Result<T, E>.
 
-#ifndef EASYNAV_CORE__RESULT_HPP_
-#define EASYNAV_CORE__RESULT_HPP_
+#ifndef EASYNAV_COMMON__RESULT_HPP_
+#define EASYNAV_COMMON__RESULT_HPP_
 
 #include <variant>
 #include <functional>
 #include <stdexcept>
 
-namespace easynav_common
+namespace easynav
 {
 
 /**
@@ -165,6 +165,6 @@ private:
   ValueType value_;
 };
 
-}  // namespace easynav_common
+}  // namespace easynav
 
-#endif  // EASYNAV_CORE__RESULT_HPP_
+#endif  // EASYNAV_COMMON__RESULT_HPP_

--- a/easynav_common/src/easynav_common/Configuration.cpp
+++ b/easynav_common/src/easynav_common/Configuration.cpp
@@ -28,7 +28,7 @@
 
 #include "easynav_common/Configuration.hpp"
 
-namespace easynav_common
+namespace easynav
 {
 
 ConfigurationValue::ConfigurationValue()
@@ -107,4 +107,4 @@ ConfigurationValue::try_double_vector() const
   return std::get_if<std::vector<double>>(&value_);
 }
 
-}  // namespace easynav_common
+}  // namespace easynav

--- a/easynav_controller/include/easynav_controller/ControllerNode.hpp
+++ b/easynav_controller/include/easynav_controller/ControllerNode.hpp
@@ -20,14 +20,14 @@
 /// \file
 /// \brief Declaration of the ControllerNode lifecycle node, ROS 2 interface for EasyNav core.
 
-#ifndef EASYNAV_CONTROLLER__EASYNAVNODE_HPP_
-#define EASYNAV_CONTROLLER__EASYNAVNODE_HPP_
+#ifndef EASYNAV_CONTROLLER__CONTROLLERNODE_HPP_
+#define EASYNAV_CONTROLLER__CONTROLLERNODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace easynav_controller
+namespace easynav
 {
 
 /// \file
@@ -136,6 +136,6 @@ private:
   void controller_cycle();
 };
 
-}  // namespace easynav_controller
+}  // namespace easynav
 
-#endif  // EASYNAV_CONTROLLER__EASYNAVNODE_HPP_
+#endif  // EASYNAV_CONTROLLER__CONTROLLERNODE_HPP_

--- a/easynav_controller/src/easynav_controller/ControllerNode.cpp
+++ b/easynav_controller/src/easynav_controller/ControllerNode.cpp
@@ -26,7 +26,7 @@
 
 #include "easynav_controller/ControllerNode.hpp"
 
-namespace easynav_controller
+namespace easynav
 {
 
 using namespace std::chrono_literals;
@@ -101,4 +101,4 @@ ControllerNode::controller_cycle()
 }
 
 
-}  // namespace easynav_controller
+}  // namespace easynav

--- a/easynav_localizer/include/easynav_localizer/LocalizerNode.hpp
+++ b/easynav_localizer/include/easynav_localizer/LocalizerNode.hpp
@@ -27,7 +27,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace easynav_localizer
+namespace easynav
 {
 
 /// \file
@@ -136,6 +136,6 @@ private:
   void localizer_cycle();
 };
 
-}  // namespace easynav_localizer
+}  // namespace easynav
 
 #endif  // EASYNAV_LOCALIZER__EASYNAVNODE_HPP_

--- a/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
+++ b/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
@@ -26,7 +26,7 @@
 
 #include "easynav_localizer/LocalizerNode.hpp"
 
-namespace easynav_localizer
+namespace easynav
 {
 
 using namespace std::chrono_literals;
@@ -101,4 +101,4 @@ LocalizerNode::localizer_cycle()
 }
 
 
-}  // namespace easynav_localizer
+}  // namespace easynav

--- a/easynav_maps_manager/include/easynav_maps_manager/MapTypeBase.hpp
+++ b/easynav_maps_manager/include/easynav_maps_manager/MapTypeBase.hpp
@@ -29,7 +29,7 @@
 
 #include "easynav_sensors/Perceptions.hpp"
 
-namespace easynav_maps_manager
+namespace easynav
 {
 
 /**
@@ -86,6 +86,6 @@ private:
   // std::shared_ptr<T> map_; ///< Internal representation of the managed map.
 };
 
-}  // namespace easynav_maps_manager
+}  // namespace easynav
 
 #endif  // EASYNAV_MAPSMANAGER__MAPSTYPEBASE_HPP_

--- a/easynav_maps_manager/include/easynav_maps_manager/MapsManagerNode.hpp
+++ b/easynav_maps_manager/include/easynav_maps_manager/MapsManagerNode.hpp
@@ -20,14 +20,14 @@
 /// \file
 /// \brief Declaration of the MapsManagerNode lifecycle node, ROS 2 interface for EasyNav core.
 
-#ifndef EASYNAV_MAPSMANAGER__EASYNAVNODE_HPP_
-#define EASYNAV_MAPSMANAGER__EASYNAVNODE_HPP_
+#ifndef EASYNAV_MAPSMANAGER__MAPSMANAGERNODE_HPP_
+#define EASYNAV_MAPSMANAGER__MAPSMANAGERNODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace easynav_maps_manager
+namespace easynav
 {
 
 /// \file
@@ -137,6 +137,6 @@ private:
   void maps_manager_cycle();
 };
 
-}  // namespace easynav_maps_manager
+}  // namespace easynav
 
-#endif  // EASYNAV_MAPSMANAGER__EASYNAVNODE_HPP_
+#endif  // EASYNAV_MAPSMANAGER__MAPSMANAGERNODE_HPP_

--- a/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
@@ -26,7 +26,7 @@
 
 #include "easynav_maps_manager/MapsManagerNode.hpp"
 
-namespace easynav_maps_manager
+namespace easynav
 {
 
 using namespace std::chrono_literals;
@@ -101,4 +101,4 @@ MapsManagerNode::maps_manager_cycle()
 }
 
 
-}  // namespace easynav_maps_manager
+}  // namespace easynav

--- a/easynav_planner/include/easynav_planner/PlannerNode.hpp
+++ b/easynav_planner/include/easynav_planner/PlannerNode.hpp
@@ -20,14 +20,14 @@
 /// \file
 /// \brief Declaration of the PlannerNode lifecycle node, ROS 2 interface for EasyNav core.
 
-#ifndef EASYNAV_PLANNER__EASYNAVNODE_HPP_
-#define EASYNAV_PLANNER__EASYNAVNODE_HPP_
+#ifndef EASYNAV_PLANNER__PLANNERNODE_HPP_
+#define EASYNAV_PLANNER__PLANNERNODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace easynav_planner
+namespace easynav
 {
 
 /// \file
@@ -136,6 +136,6 @@ private:
   void planner_cycle();
 };
 
-}  // namespace easynav_planner
+}  // namespace easynav
 
-#endif  // EASYNAV_PLANNER__EASYNAVNODE_HPP_
+#endif  // EASYNAV_PLANNER__PLANNERNODE_HPP_

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -26,7 +26,7 @@
 
 #include "easynav_planner/PlannerNode.hpp"
 
-namespace easynav_planner
+namespace easynav
 {
 
 using namespace std::chrono_literals;
@@ -101,4 +101,4 @@ PlannerNode::planner_cycle()
 }
 
 
-}  // namespace easynav_planner
+}  // namespace easynav

--- a/easynav_sensors/include/easynav_sensors/Perceptions.hpp
+++ b/easynav_sensors/include/easynav_sensors/Perceptions.hpp
@@ -34,7 +34,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace easynav_sensors
+namespace easynav
 {
 
 /**
@@ -60,6 +60,6 @@ struct Perception
  */
 typedef std::vector<Perception> Perceptions;
 
-}  // namespace easynav_sensors
+}  // namespace easynav
 
 #endif  // EASYNAV_SENSORS__PERCEPTIONS_HPP_

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -27,7 +27,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace easynav_sensors
+namespace easynav
 {
 
 /// \file
@@ -136,6 +136,6 @@ private:
   void sensors_cycle();
 };
 
-}  // namespace easynav_sensors
+}  // namespace easynav
 
 #endif  // EASYNAV_SENSORS__SENSORNODE_HPP_

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -26,7 +26,7 @@
 
 #include "easynav_sensors/SensorsNode.hpp"
 
-namespace easynav_sensors
+namespace easynav
 {
 
 using namespace std::chrono_literals;
@@ -101,4 +101,4 @@ SensorsNode::sensors_cycle()
 }
 
 
-}  // namespace easynav_sensors
+}  // namespace easynav

--- a/easynav_system/include/easynav_system/SystemNode.hpp
+++ b/easynav_system/include/easynav_system/SystemNode.hpp
@@ -20,8 +20,8 @@
 /// \file
 /// \brief Declaration of the SystemNode lifecycle node, ROS 2 interface for EasyNav core.
 
-#ifndef EASYNAV_SYSTEM__EASYNAVNODE_HPP_
-#define EASYNAV_SYSTEM__EASYNAVNODE_HPP_
+#ifndef EASYNAV_SYSTEM__SYSTEMNODE_HPP_
+#define EASYNAV_SYSTEM__SYSTEMNODE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/macros.hpp"
@@ -33,7 +33,7 @@
 #include "easynav_planner/PlannerNode.hpp"
 #include "easynav_sensors/SensorsNode.hpp"
 
-namespace easynav_system
+namespace easynav
 {
 
 /// \file
@@ -142,11 +142,11 @@ private:
    */
   rclcpp::TimerBase::SharedPtr system_main_timer_;
 
-  easynav_controller::ControllerNode::SharedPtr controller_node_;
-  easynav_localizer::LocalizerNode::SharedPtr localizer_node_;
-  easynav_maps_manager::MapsManagerNode::SharedPtr maps_manager_node_;
-  easynav_planner::PlannerNode::SharedPtr planner_node_;
-  easynav_sensors::SensorsNode::SharedPtr sensors_node_;
+  ControllerNode::SharedPtr controller_node_;
+  LocalizerNode::SharedPtr localizer_node_;
+  MapsManagerNode::SharedPtr maps_manager_node_;
+  PlannerNode::SharedPtr planner_node_;
+  SensorsNode::SharedPtr sensors_node_;
 
   /**
    * @brief Executes a single cycle.
@@ -156,6 +156,6 @@ private:
   void system_cycle();
 };
 
-}  // namespace easynav_system
+}  // namespace easynav
 
-#endif  // EASYNAV_SYSTEM__EASYNAVNODE_HPP_
+#endif  // EASYNAV_SYSTEM__SYSTEMNODE_HPP_

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -36,7 +36,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 
-namespace easynav_system
+namespace easynav
 {
 
 using namespace std::chrono_literals;
@@ -46,11 +46,11 @@ SystemNode::SystemNode(const rclcpp::NodeOptions & options)
 {
   realtime_cbg_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
 
-  controller_node_ = easynav_controller::ControllerNode::make_shared();
-  localizer_node_ = easynav_localizer::LocalizerNode::make_shared();
-  maps_manager_node_ = easynav_maps_manager::MapsManagerNode::make_shared();
-  planner_node_ = easynav_planner::PlannerNode::make_shared();
-  sensors_node_ = easynav_sensors::SensorsNode::make_shared();
+  controller_node_ = ControllerNode::make_shared();
+  localizer_node_ = LocalizerNode::make_shared();
+  maps_manager_node_ = MapsManagerNode::make_shared();
+  planner_node_ = PlannerNode::make_shared();
+  sensors_node_ = SensorsNode::make_shared();
 }
 
 using CallbackReturnT = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
@@ -170,4 +170,4 @@ SystemNode::get_system_nodes()
   return ret;
 }
 
-}  // namespace easynav_system
+}  // namespace easynav

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   rclcpp::experimental::executors::EventsExecutor exe_nort, exe_rt;
-  auto system_node = easynav_system::SystemNode::make_shared();
+  auto system_node = easynav::SystemNode::make_shared();
 
   exe_nort.add_node(system_node->get_node_base_interface());
   exe_rt.add_callback_group(system_node->get_real_time_cbg(),


### PR DESCRIPTION
Put all names under a common `easynav` namespace. This name is shorter and will also simplify using the easynav modules that come from different packages.

I also updated some include guards to match the module/header names.