### PR TITLE
Isolate Perceptions type from sensor utility functions

### DIFF
--- a/easynav_common/CMakeLists.txt
+++ b/easynav_common/CMakeLists.txt
@@ -23,16 +23,11 @@ set(dependencies
   rclcpp_lifecycle
   geometry_msgs
   nav_msgs
-  pcl_conversions
   pcl_ros
-  tf2
-  tf2_ros
-  tf2_eigen
 )
 
 add_library(${PROJECT_NAME} SHARED
   src/easynav_common/Configuration.cpp
-  src/easynav_common/Perceptions.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/easynav_common/include/easynav_common/types/Perceptions.hpp
+++ b/easynav_common/include/easynav_common/types/Perceptions.hpp
@@ -18,26 +18,19 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 /// \file
-/// \brief Definitions for handling sensor perceptions, including point cloud conversion, fusion, and subscription creation.
+/// \brief Definitions for a unified Perception type.
 
 #ifndef EASYNAV_COMMON_TYPES__PERCEPTIONS_HPP_
 #define EASYNAV_COMMON_TYPES__PERCEPTIONS_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
-#include "pcl_conversions/pcl_conversions.h"
-#include "pcl/point_types_conversion.h"
-#include "pcl/common/transforms.h"
 #include "pcl/point_cloud.h"
 #include "pcl/point_types.h"
-#include "tf2_eigen/tf2_eigen.hpp"
-
-#include "sensor_msgs/msg/laser_scan.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
 
 #include "rclcpp/time.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace easynav
 {
@@ -55,7 +48,6 @@ struct Perception
   rclcpp::Time stamp;                       ///< Timestamp of the perception.
   std::string frame_id;                     ///< Frame ID associated with the data.
   bool valid = false;                       ///< Whether the perception is valid or usable.
-  rclcpp::SubscriptionBase::SharedPtr subscription; ///< ROS 2 subscription linked to the data source.
 };
 
 /**
@@ -64,69 +56,6 @@ struct Perception
  */
 using Perceptions = std::vector<std::shared_ptr<Perception>>;
 
-/**
- * @brief Converts a LaserScan message into a PCL point cloud.
- *
- * @param scan The input LaserScan message.
- * @param pc The output PCL point cloud to be filled.
- */
-void convert(const sensor_msgs::msg::LaserScan & scan, pcl::PointCloud<pcl::PointXYZ> & pc);
-
-/**
- * @brief Fuses a collection of Perceptions into a single PointCloud2, transforming all frames into a common target frame.
- *
- * Each perception is checked for validity. Valid perceptions are transformed using tf2
- * into the specified target frame before being merged.
- *
- * @param perceptions Vector of shared pointers to Perception objects.
- * @param target_frame Target frame ID into which all clouds will be transformed.
- * @param tf_buffer A tf2 buffer used to lookup and perform frame transformations.
- * @param output_msg Output fused PointCloud2 message.
- */
-void fuse_perceptions(
-  const Perceptions & perceptions,
-  const std::string & target_frame,
-  tf2_ros::Buffer & tf_buffer,
-  sensor_msgs::msg::PointCloud2 & output_msg);
-
-/**
- * @brief Creates a subscription for a given sensor message type and binds it to a Perception object.
- *
- * @tparam MsgT The sensor message type (e.g., LaserScan, PointCloud2).
- * @param node Reference to the LifecycleNode where the subscription is created.
- * @param topic Name of the ROS 2 topic to subscribe to.
- * @param perception Shared pointer to the Perception structure that will store received data.
- * @param cbg Callback group to assign the subscription to.
- * @return Shared pointer to the created SubscriptionBase.
- */
-template<typename MsgT>
-rclcpp::SubscriptionBase::SharedPtr create_typed_subscription(
-  rclcpp_lifecycle::LifecycleNode & node,
-  const std::string & topic,
-  std::shared_ptr<Perception> perception,
-  rclcpp::CallbackGroup::SharedPtr cbg);
-
-/**
- * @brief Specialization of create_typed_subscription for LaserScan messages.
- */
-template<>
-rclcpp::SubscriptionBase::SharedPtr
-create_typed_subscription<sensor_msgs::msg::LaserScan>(
-  rclcpp_lifecycle::LifecycleNode & node,
-  const std::string & topic,
-  std::shared_ptr<Perception> perception,
-  rclcpp::CallbackGroup::SharedPtr cbg);
-
-/**
- * @brief Specialization of create_typed_subscription for PointCloud2 messages.
- */
-template<>
-rclcpp::SubscriptionBase::SharedPtr
-create_typed_subscription<sensor_msgs::msg::PointCloud2>(
-  rclcpp_lifecycle::LifecycleNode & node,
-  const std::string & topic,
-  std::shared_ptr<Perception> perception,
-  rclcpp::CallbackGroup::SharedPtr cbg);
 }  // namespace easynav
 
 #endif  // EASYNAV_COMMON_TYPES__PERCEPTIONS_HPP_

--- a/easynav_common/package.xml
+++ b/easynav_common/package.xml
@@ -10,13 +10,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp_lifecycle</depend>
-  <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>tf2</depend>
-  <depend>tf2_ros</depend>
-  <depend>tf2_eigen</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/easynav_sensors/CMakeLists.txt
+++ b/easynav_sensors/CMakeLists.txt
@@ -14,19 +14,31 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(pcl_conversions REQUIRED)
+find_package(pcl_ros REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_eigen REQUIRED)
 
 find_package(easynav_common REQUIRED)
 
 set(dependencies
   rclcpp
   rclcpp_lifecycle
+  pcl_conversions
+  pcl_ros
+  tf2
+  tf2_ros
+  tf2_eigen
   easynav_common
 )
 
 include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED
-  src/easynav_sensors/SensorsNode.cpp)
+  src/easynav_sensors/SensorsNode.cpp
+  src/easynav_sensors/SensorsUtils.cpp
+)
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
 
 install(DIRECTORY include/

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -185,6 +185,11 @@ private:
   Perceptions perceptions_;
 
   /**
+   * @brief Container perception subscriptions.
+   */
+  std::vector<rclcpp::SubscriptionBase::SharedPtr> subscriptions_;
+
+  /**
    * @brief Maximum age (in seconds) after which a perception is discarded.
    */
   double forget_time_;

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -38,6 +38,12 @@
 namespace easynav
 {
 
+struct PerceptionData
+{
+  std::shared_ptr<Perception> perception;
+  rclcpp::SubscriptionBase::SharedPtr subscription;
+};
+
 /**
  * @class SensorsNode
  * @brief ROS 2 lifecycle node that manages sensor fusion for the Easy Navigation system.
@@ -123,7 +129,7 @@ public:
    *
    * @return Const reference to the list of perceptions.
    */
-  const Perceptions & get_perceptions() const {return perceptions_;}
+  const Perceptions get_perceptions() const;
 
   /**
    * @brief Updates the node's behavior based on the provided navigation state.
@@ -180,14 +186,9 @@ private:
   void sensors_cycle_nort();
 
   /**
-   * @brief Container storing current active perceptions.
+   * @brief Container storing current active perceptions and their subscription objects
    */
-  Perceptions perceptions_;
-
-  /**
-   * @brief Container perception subscriptions.
-   */
-  std::vector<rclcpp::SubscriptionBase::SharedPtr> subscriptions_;
+  std::vector<PerceptionData> perceptions_;
 
   /**
    * @brief Maximum age (in seconds) after which a perception is discarded.

--- a/easynav_sensors/include/easynav_sensors/SensorsUtils.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsUtils.hpp
@@ -1,0 +1,87 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// licensed under the GNU General Public License v3.0.
+// See <http://www.gnu.org/licenses/> for details.
+//
+// Easy Navigation program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/// \file
+/// \brief uTILITY FUNCTIONS for handling sensor perceptions, including point cloud conversion, fusion, and subscription creation.
+
+#ifndef EASYNAV_SENSORS__SENSORSUTILS_HPP_
+#define EASYNAV_SENSORS__SENSORSUTILS_HPP_
+
+#include <string>
+
+#include "pcl/point_cloud.h"
+#include "pcl/point_types.h"
+
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "tf2_ros/buffer.h"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "easynav_common/types/Perceptions.hpp"
+
+namespace easynav
+{
+
+/**
+ * @brief Converts a LaserScan message into a PCL point cloud.
+ *
+ * @param scan The input LaserScan message.
+ * @param pc The output PCL point cloud to be filled.
+ */
+void convert(const sensor_msgs::msg::LaserScan & scan, pcl::PointCloud<pcl::PointXYZ> & pc);
+
+/**
+ * @brief Fuses a collection of Perceptions into a single PointCloud2, transforming all frames into a common target frame.
+ *
+ * Each perception is checked for validity. Valid perceptions are transformed using tf2
+ * into the specified target frame before being merged.
+ *
+ * @param perceptions Vector of shared pointers to Perception objects.
+ * @param target_frame Target frame ID into which all clouds will be transformed.
+ * @param tf_buffer A tf2 buffer used to lookup and perform frame transformations.
+ * @param output_msg Output fused PointCloud2 message.
+ */
+void fuse_perceptions(
+  const Perceptions & perceptions,
+  const std::string & target_frame,
+  tf2_ros::Buffer & tf_buffer,
+  sensor_msgs::msg::PointCloud2 & output_msg);
+
+/**
+ * @brief Creates a subscription for a given sensor message type and binds it to a Perception object.
+ *
+ * @tparam MsgT The sensor message type (e.g., LaserScan, PointCloud2).
+ * @param node Reference to the LifecycleNode where the subscription is created.
+ * @param topic Name of the ROS 2 topic to subscribe to.
+ * @param perception Shared pointer to the Perception structure that will store received data.
+ * @param cbg Callback group to assign the subscription to.
+ * @return Shared pointer to the created SubscriptionBase.
+ */
+template<typename MsgT>
+rclcpp::SubscriptionBase::SharedPtr create_typed_subscription(
+  rclcpp_lifecycle::LifecycleNode & node,
+  const std::string & topic,
+  std::shared_ptr<Perception> perception,
+  rclcpp::CallbackGroup::SharedPtr cbg
+);
+
+}  // namespace easynav
+
+#endif  // EASYNAV_SENSORS__SENSORSUTILS_HPP_

--- a/easynav_sensors/package.xml
+++ b/easynav_sensors/package.xml
@@ -11,6 +11,11 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_eigen</depend>
 
   <depend>easynav_common</depend>
 

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -31,6 +31,7 @@
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
 #include "easynav_sensors/SensorsNode.hpp"
+#include "easynav_sensors/SensorsUtils.hpp"
 
 namespace easynav
 {
@@ -100,18 +101,20 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
     perception_entry->stamp = now();
     perception_entry->valid = false;
 
-    perceptions_.push_back(perception_entry);
+    rclcpp::SubscriptionBase::SharedPtr perception_sub;
 
     if (msg_type == "LaserScan") {
-      perception_entry->subscription = create_typed_subscription<sensor_msgs::msg::LaserScan>(
-        *this, topic, perception_entry, realtime_cbg_);
+      perception_sub = create_typed_subscription<sensor_msgs::msg::LaserScan>(
+      *this, topic, perception_entry, realtime_cbg_);
     } else if (msg_type == "PointCloud") {
-      perception_entry->subscription = create_typed_subscription<sensor_msgs::msg::PointCloud2>(
-        *this, topic, perception_entry, realtime_cbg_);
+      perception_sub = create_typed_subscription<sensor_msgs::msg::PointCloud2>(
+      *this, topic, perception_entry, realtime_cbg_);
     } else {
       RCLCPP_ERROR(get_logger(), "Sensor type [%s] not supported", msg_type.c_str());
       return CallbackReturnT::FAILURE;
     }
+    perceptions_.push_back(perception_entry);
+    subscriptions_.push_back(perception_sub);
   }
 
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());

--- a/easynav_sensors/src/easynav_sensors/SensorsUtils.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsUtils.cpp
@@ -25,13 +25,15 @@
 #include <vector>
 
 #include "pcl/point_types.h"
+#include "pcl/common/transforms.h"
 #include "pcl_conversions/pcl_conversions.h"
-#include "pcl/point_types_conversion.h"
+#include "tf2_eigen/tf2_eigen.hpp"
 
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
 #include "easynav_common/types/Perceptions.hpp"
+#include "easynav_sensors/SensorsUtils.hpp"
 
 namespace easynav
 {
@@ -128,16 +130,6 @@ void fuse_perceptions(
   }
 
   output_msg.header.stamp = latest_stamp;
-}
-
-template<typename MsgT>
-rclcpp::SubscriptionBase::SharedPtr create_typed_subscription(
-  rclcpp_lifecycle::LifecycleNode & node,
-  const std::string & topic,
-  std::shared_ptr<Perception> perception)
-{
-  std::cerr << "Generic transform" << std::endl;
-  return nullptr;
 }
 
 template<>

--- a/easynav_sensors/tests/sensors_node_tests.cpp
+++ b/easynav_sensors/tests/sensors_node_tests.cpp
@@ -353,7 +353,6 @@ TEST_F(SensorsNodeTestCase, percept_laserscan)
   ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
   ASSERT_EQ(perceptions[0]->frame_id, "base_laser");
   ASSERT_EQ(perceptions[0]->valid, true);
-  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 
   {
     auto start = test_node->now();
@@ -366,7 +365,6 @@ TEST_F(SensorsNodeTestCase, percept_laserscan)
   ASSERT_EQ(perceptions[0]->data.size(), 16u);
   ASSERT_EQ(perceptions[0]->frame_id, "base_laser");
   ASSERT_EQ(perceptions[0]->valid, false);
-  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 }
 
 TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
@@ -455,11 +453,9 @@ TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
     ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
     ASSERT_NEAR((test_node->now() - perceptions[1]->stamp).seconds(), 0.02, 0.001);
     ASSERT_EQ(perceptions[1]->valid, true);
-    // ASSERT_NE(perceptions[1]->subscription, nullptr);
     ASSERT_LT(perceptions[1]->stamp, perceptions[0]->stamp);
 
     ASSERT_NE(fused_perception, nullptr);
@@ -497,10 +493,8 @@ TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
     ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
     ASSERT_EQ(perceptions[1]->valid, false);
-    // ASSERT_NE(perceptions[1]->subscription, nullptr);
 
     ASSERT_NE(fused_perception, nullptr);
 
@@ -572,7 +566,6 @@ TEST_F(SensorsNodeTestCase, percept_pc2)
   ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
   ASSERT_EQ(perceptions[0]->frame_id, "base_lidar3d");
   ASSERT_EQ(perceptions[0]->valid, true);
-  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 
   {
     auto start = test_node->now();
@@ -585,7 +578,6 @@ TEST_F(SensorsNodeTestCase, percept_pc2)
   ASSERT_EQ(perceptions[0]->data.size(), 16u);
   ASSERT_EQ(perceptions[0]->frame_id, "base_lidar3d");
   ASSERT_EQ(perceptions[0]->valid, false);
-  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 }
 
 
@@ -684,16 +676,13 @@ TEST_F(SensorsNodeTestCase, percept_fuse_all)
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
     ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
     ASSERT_NEAR((test_node->now() - perceptions[1]->stamp).seconds(), 0.02, 0.001);
     ASSERT_EQ(perceptions[1]->valid, true);
-    // ASSERT_NE(perceptions[1]->subscription, nullptr);
     ASSERT_LT(perceptions[1]->stamp, perceptions[0]->stamp);
     ASSERT_EQ(perceptions[2]->data.size(), 16u);
     ASSERT_NEAR((test_node->now() - perceptions[2]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[2]->valid, true);
-    // ASSERT_NE(perceptions[2]->subscription, nullptr);
     ASSERT_NE(fused_perception, nullptr);
 
     pcl::PointCloud<pcl::PointXYZ> fused_pcl;
@@ -732,13 +721,10 @@ TEST_F(SensorsNodeTestCase, percept_fuse_all)
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
     ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
     ASSERT_EQ(perceptions[1]->valid, false);
-    // ASSERT_NE(perceptions[1]->subscription, nullptr);
     ASSERT_EQ(perceptions[2]->data.size(), 16u);
     ASSERT_EQ(perceptions[2]->valid, false);
-    // ASSERT_NE(perceptions[2]->subscription, nullptr);
 
     ASSERT_NE(fused_perception, nullptr);
 

--- a/easynav_sensors/tests/sensors_node_tests.cpp
+++ b/easynav_sensors/tests/sensors_node_tests.cpp
@@ -19,19 +19,15 @@
 
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
-#include "easynav_common/types/Perceptions.hpp"
 #include "easynav_sensors/SensorsNode.hpp"
+#include "easynav_sensors/SensorsUtils.hpp"
 
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "pcl/point_types.h"
 #include "pcl_conversions/pcl_conversions.h"
-#include "pcl/point_types_conversion.h"
-#include "pcl/common/transforms.h"
-#include "tf2_eigen/tf2_eigen.hpp"
 #include "tf2_ros/transform_broadcaster.h"
-#include "tf2/transform_datatypes.h"
 
 #include "gtest/gtest.h"
 
@@ -357,7 +353,7 @@ TEST_F(SensorsNodeTestCase, percept_laserscan)
   ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
   ASSERT_EQ(perceptions[0]->frame_id, "base_laser");
   ASSERT_EQ(perceptions[0]->valid, true);
-  ASSERT_NE(perceptions[0]->subscription, nullptr);
+  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 
   {
     auto start = test_node->now();
@@ -370,7 +366,7 @@ TEST_F(SensorsNodeTestCase, percept_laserscan)
   ASSERT_EQ(perceptions[0]->data.size(), 16u);
   ASSERT_EQ(perceptions[0]->frame_id, "base_laser");
   ASSERT_EQ(perceptions[0]->valid, false);
-  ASSERT_NE(perceptions[0]->subscription, nullptr);
+  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 }
 
 TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
@@ -436,14 +432,16 @@ TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
   {
     auto start = test_node->now();
     while (test_node->now() - start < 1s) {
-      transform.header.stamp = test_node->now();
+      // Common tf time to avoid "extrapolation into the future" errors
+      const auto tf_time = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_1";
       tf_broadcaster->sendTransform(transform);
-      transform.header.stamp = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_2";
       tf_broadcaster->sendTransform(transform);
 
-      auto time1 = test_node->now();
+      auto time1 = tf_time - 10ms;
       auto time2 = time1 - 10ms;
 
       laser1_pub->publish(get_scan_test_3(time1));
@@ -455,13 +453,13 @@ TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
 
     ASSERT_EQ(perceptions.size(), 2u);
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
-    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
+    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    ASSERT_NE(perceptions[0]->subscription, nullptr);
+    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
-    ASSERT_NEAR((test_node->now() - perceptions[1]->stamp).seconds(), 0.0, 0.02);
+    ASSERT_NEAR((test_node->now() - perceptions[1]->stamp).seconds(), 0.02, 0.001);
     ASSERT_EQ(perceptions[1]->valid, true);
-    ASSERT_NE(perceptions[1]->subscription, nullptr);
+    // ASSERT_NE(perceptions[1]->subscription, nullptr);
     ASSERT_LT(perceptions[1]->stamp, perceptions[0]->stamp);
 
     ASSERT_NE(fused_perception, nullptr);
@@ -478,30 +476,31 @@ TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
   {
     auto start = test_node->now();
     while (test_node->now() - start < 1s) {
-      transform.header.stamp = test_node->now();
+      // Common tf time to avoid "extrapolation into the future" errors
+      const auto tf_time = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_1";
       tf_broadcaster->sendTransform(transform);
-      transform.header.stamp = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_2";
       tf_broadcaster->sendTransform(transform);
 
-      auto time1 = test_node->now();
+      auto time1 = tf_time - 10ms;
       auto time2 = time1 - 10ms;
 
       laser1_pub->publish(get_scan_test_3(time1));
       exe.spin_some();
     }
-
     const auto & perceptions = sensors_node->get_perceptions();
 
     ASSERT_EQ(perceptions.size(), 2u);
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
-    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
+    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    ASSERT_NE(perceptions[0]->subscription, nullptr);
+    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
     ASSERT_EQ(perceptions[1]->valid, false);
-    ASSERT_NE(perceptions[1]->subscription, nullptr);
+    // ASSERT_NE(perceptions[1]->subscription, nullptr);
 
     ASSERT_NE(fused_perception, nullptr);
 
@@ -573,7 +572,7 @@ TEST_F(SensorsNodeTestCase, percept_pc2)
   ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
   ASSERT_EQ(perceptions[0]->frame_id, "base_lidar3d");
   ASSERT_EQ(perceptions[0]->valid, true);
-  ASSERT_NE(perceptions[0]->subscription, nullptr);
+  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 
   {
     auto start = test_node->now();
@@ -586,7 +585,7 @@ TEST_F(SensorsNodeTestCase, percept_pc2)
   ASSERT_EQ(perceptions[0]->data.size(), 16u);
   ASSERT_EQ(perceptions[0]->frame_id, "base_lidar3d");
   ASSERT_EQ(perceptions[0]->valid, false);
-  ASSERT_NE(perceptions[0]->subscription, nullptr);
+  // ASSERT_NE(perceptions[0]->subscription, nullptr);
 }
 
 
@@ -655,21 +654,22 @@ TEST_F(SensorsNodeTestCase, percept_fuse_all)
 
   ASSERT_EQ(sensors_node->get_current_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
-
   {
     auto start = test_node->now();
     while (test_node->now() - start < 1s) {
-      transform.header.stamp = test_node->now();
+      // Common tf time to avoid "extrapolation into the future" errors
+      const auto tf_time = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_1";
       tf_broadcaster->sendTransform(transform);
-      transform.header.stamp = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_2";
       tf_broadcaster->sendTransform(transform);
-      transform.header.stamp = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_lidar3d";
       tf_broadcaster->sendTransform(transform);
 
-      auto time1 = test_node->now();
+      auto time1 = tf_time - 10ms;
       auto time2 = time1 - 10ms;
 
       laser1_pub->publish(get_scan_test_3(time1));
@@ -682,18 +682,18 @@ TEST_F(SensorsNodeTestCase, percept_fuse_all)
 
     ASSERT_EQ(perceptions.size(), 3u);
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
-    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
+    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    ASSERT_NE(perceptions[0]->subscription, nullptr);
+    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
-    ASSERT_NEAR((test_node->now() - perceptions[1]->stamp).seconds(), 0.0, 0.02);
+    ASSERT_NEAR((test_node->now() - perceptions[1]->stamp).seconds(), 0.02, 0.001);
     ASSERT_EQ(perceptions[1]->valid, true);
-    ASSERT_NE(perceptions[1]->subscription, nullptr);
+    // ASSERT_NE(perceptions[1]->subscription, nullptr);
     ASSERT_LT(perceptions[1]->stamp, perceptions[0]->stamp);
     ASSERT_EQ(perceptions[2]->data.size(), 16u);
-    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
+    ASSERT_NEAR((test_node->now() - perceptions[2]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[2]->valid, true);
-    ASSERT_NE(perceptions[2]->subscription, nullptr);
+    // ASSERT_NE(perceptions[2]->subscription, nullptr);
     ASSERT_NE(fused_perception, nullptr);
 
     pcl::PointCloud<pcl::PointXYZ> fused_pcl;
@@ -708,16 +708,18 @@ TEST_F(SensorsNodeTestCase, percept_fuse_all)
   {
     auto start = test_node->now();
     while (test_node->now() - start < 1s) {
-      transform.header.stamp = test_node->now();
+      // Common tf time to avoid "extrapolation into the future" errors
+      const auto tf_time = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_1";
       tf_broadcaster->sendTransform(transform);
-      transform.header.stamp = test_node->now();
+      transform.header.stamp = tf_time;
       transform.child_frame_id = "base_laser_2";
       tf_broadcaster->sendTransform(transform);
       transform.child_frame_id = "base_lidar3d";
       tf_broadcaster->sendTransform(transform);
 
-      auto time1 = test_node->now();
+      auto time1 = tf_time - 10ms;
       auto time2 = time1 - 10ms;
 
       laser1_pub->publish(get_scan_test_3(time1));
@@ -728,15 +730,15 @@ TEST_F(SensorsNodeTestCase, percept_fuse_all)
 
     ASSERT_EQ(perceptions.size(), 3u);
     ASSERT_EQ(perceptions[0]->data.size(), 16u);
-    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.0, 0.001);
+    ASSERT_NEAR((test_node->now() - perceptions[0]->stamp).seconds(), 0.01, 0.001);
     ASSERT_EQ(perceptions[0]->valid, true);
-    ASSERT_NE(perceptions[0]->subscription, nullptr);
+    // ASSERT_NE(perceptions[0]->subscription, nullptr);
     ASSERT_EQ(perceptions[1]->data.size(), 16u);
     ASSERT_EQ(perceptions[1]->valid, false);
-    ASSERT_NE(perceptions[1]->subscription, nullptr);
+    // ASSERT_NE(perceptions[1]->subscription, nullptr);
     ASSERT_EQ(perceptions[2]->data.size(), 16u);
     ASSERT_EQ(perceptions[2]->valid, false);
-    ASSERT_NE(perceptions[2]->subscription, nullptr);
+    // ASSERT_NE(perceptions[2]->subscription, nullptr);
 
     ASSERT_NE(fused_perception, nullptr);
 


### PR DESCRIPTION
Separate the `Perception` structure from the other utility functions like `fuse_perceptions`, `convert`, and `create_typed_subscription`.

This is mainly to separate the types from the operations and to remove dependencies from `easynav_common`.