### PR TITLE
Fix #28 - use no-rt cbg for no-rt timer

### DIFF
--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -121,8 +121,7 @@ SystemNode::on_activate(const rclcpp_lifecycle::State & state)
     }
   }
 
-  system_main_nort_timer_ = create_timer(300ms, std::bind(&SystemNode::system_cycle, this),
-    realtime_cbg_);
+  system_main_nort_timer_ = create_timer(300ms, std::bind(&SystemNode::system_cycle, this));
 
   return CallbackReturnT::SUCCESS;
 }

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -121,7 +121,7 @@ SystemNode::on_activate(const rclcpp_lifecycle::State & state)
     }
   }
 
-  system_main_nort_timer_ = create_timer(300ms, std::bind(&SystemNode::system_cycle, this));
+  system_main_nort_timer_ = create_timer(30ms, std::bind(&SystemNode::system_cycle, this));
 
   return CallbackReturnT::SUCCESS;
 }


### PR DESCRIPTION
Dear all,

This fixes #28 . Timer for no-rt control cycle was created with the rt cbg.
