### PR TITLE
Complete Dummey Controllers

### DIFF
--- a/easynav_controller/include/easynav_controller/DummyController.hpp
+++ b/easynav_controller/include/easynav_controller/DummyController.hpp
@@ -82,6 +82,8 @@ private:
    */
   geometry_msgs::msg::TwistStamped cmd_vel_ {};
 
+  double cycle_time_rt_;
+  double cycle_time_nort_;
 };
 
 }  // namespace easynav

--- a/easynav_controller/src/easynav_controller/ControllerNode.cpp
+++ b/easynav_controller/src/easynav_controller/ControllerNode.cpp
@@ -27,6 +27,7 @@
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "easynav_controller/ControllerNode.hpp"
+#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -171,6 +172,8 @@ ControllerNode::get_cmd_vel() const
 bool
 ControllerNode::cycle_rt(bool trigger)
 {
+  EASYNAV_TRACE_EVENT;
+
   if (controller_method_ == nullptr) {return false;}
 
   return controller_method_->internal_update_rt(*nav_state_, trigger);

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -30,6 +30,14 @@ namespace easynav
 
 std::expected<void, std::string> DummyController::on_initialize()
 {
+  auto node = get_node();
+  const auto & plugin_name = get_plugin_name();
+
+  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.01);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.01);
+  node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
+  node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
+
   // Initialize the odometry message
   cmd_vel_.header.stamp = get_node()->now();
   cmd_vel_.header.frame_id = "base_link";
@@ -50,6 +58,9 @@ geometry_msgs::msg::TwistStamped DummyController::get_cmd_vel()
 
 void DummyController::update_rt(const NavState & nav_state)
 {
+  auto start = get_node()->now();
+  while ((get_node()->now() - start).seconds() < cycle_time_rt_) {}
+
   cmd_vel_.header.stamp = nav_state.timestamp;
   cmd_vel_.header.frame_id = "base_link";
   // Compute the current command...

--- a/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
+++ b/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
@@ -27,6 +27,7 @@
 
 #include "nav_msgs/msg/odometry.hpp"
 #include "easynav_core/LocalizerMethodBase.hpp"
+#include "tf2_ros/transform_broadcaster.h"
 
 namespace easynav
 {
@@ -82,6 +83,11 @@ public:
 private:
   /// @brief Internal odometry placeholder.
   nav_msgs::msg::Odometry odom_ {};
+
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+
+  double cycle_time_rt_;
+  double cycle_time_nort_;
 };
 
 }  // namespace easynav

--- a/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
+++ b/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
@@ -26,6 +26,7 @@
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "easynav_localizer/LocalizerNode.hpp"
+#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -170,6 +171,8 @@ LocalizerNode::get_odom() const
 bool
 LocalizerNode::cycle_rt(bool trigger)
 {
+  EASYNAV_TRACE_EVENT;
+
   if (localizer_method_ == nullptr) {return false;}
 
   return localizer_method_->internal_update_rt(*nav_state_, trigger);
@@ -178,6 +181,8 @@ LocalizerNode::cycle_rt(bool trigger)
 void
 LocalizerNode::cycle()
 {
+  EASYNAV_TRACE_EVENT;
+
   if (localizer_method_ == nullptr) {return;}
 
   localizer_method_->internal_update(*nav_state_);

--- a/easynav_maps_manager/CMakeLists.txt
+++ b/easynav_maps_manager/CMakeLists.txt
@@ -28,7 +28,6 @@ include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED
   src/easynav_maps_manager/MapsManagerNode.cpp
-  src/easynav_maps_manager/DummyMapsManager.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -36,12 +35,26 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
 
+add_library(dummy_maps_manager SHARED
+  src/easynav_maps_manager/DummyMapsManager.cpp
+)
+target_include_directories(dummy_maps_manager PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+ament_target_dependencies(dummy_maps_manager
+  easynav_core
+  pluginlib
+)
+
+
 install(DIRECTORY include/
   DESTINATION include/
 )
 
 install(TARGETS
   ${PROJECT_NAME}
+  dummy_maps_manager
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/easynav_maps_manager/include/easynav_maps_manager/DummyMapsManager.hpp
+++ b/easynav_maps_manager/include/easynav_maps_manager/DummyMapsManager.hpp
@@ -67,6 +67,10 @@ public:
    * @param nav_state The current navigation state.
    */
   virtual void update(const NavState & nav_state) override;
+
+private:
+  double cycle_time_rt_;
+  double cycle_time_nort_;
 };
 
 }  // namespace easynav

--- a/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
@@ -29,12 +29,23 @@ namespace easynav
 
 std::expected<void, std::string> DummyMapsManager::on_initialize()
 {
+  auto node = get_node();
+  const auto & plugin_name = get_plugin_name();
+
+  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.01);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.01);
+  node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
+  node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
+
   return {};
 }
 
 void
 DummyMapsManager::update(const NavState & nav_state)
 {
+  auto start = get_node()->now();
+  while ((get_node()->now() - start).seconds() < cycle_time_nort_) {}
+
   (void)nav_state;
 }
 

--- a/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
@@ -29,6 +29,7 @@
 
 #include "easynav_maps_manager/MapsManagerNode.hpp"
 #include "easynav_core/MapsManagerBase.hpp"
+#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -152,6 +153,8 @@ MapsManagerNode::on_error(const rclcpp_lifecycle::State & state)
 void
 MapsManagerNode::cycle()
 {
+  EASYNAV_TRACE_EVENT;
+
   for (auto & map_manager : maps_managers_) {
     map_manager->internal_update(*nav_state_);
 

--- a/easynav_planner/include/easynav_planner/DummyPlanner.hpp
+++ b/easynav_planner/include/easynav_planner/DummyPlanner.hpp
@@ -67,6 +67,9 @@ public:
 private:
   /// @brief Stored path message (unused in dummy).
   nav_msgs::msg::Path path_ {};
+
+  double cycle_time_rt_;
+  double cycle_time_nort_;
 };
 
 }  // namespace easynav

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -29,6 +29,14 @@ namespace easynav
 
 std::expected<void, std::string> DummyPlanner::on_initialize()
 {
+  auto node = get_node();
+  const auto & plugin_name = get_plugin_name();
+
+  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.01);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.01);
+  node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
+  node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
+
   // Initialize the Path message
   path_.header.stamp = get_node()->now();
   path_.header.frame_id = "map";
@@ -44,6 +52,9 @@ nav_msgs::msg::Path DummyPlanner::get_path()
 
 void DummyPlanner::update(const NavState & nav_state)
 {
+  auto start = get_node()->now();
+  while ((get_node()->now() - start).seconds() < cycle_time_nort_) {}
+
   path_.header.stamp = nav_state.timestamp;
   path_.header.frame_id = "map";
   // Compute the current path...

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -28,6 +28,7 @@
 
 #include "easynav_planner/PlannerNode.hpp"
 #include "easynav_core/PlannerMethodBase.hpp"
+#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -163,6 +164,8 @@ PlannerNode::get_path() const
 void
 PlannerNode::cycle()
 {
+  EASYNAV_TRACE_EVENT;
+
   if (planner_method_ == nullptr) {return;}
 
   planner_method_->internal_update(*nav_state_);

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -31,6 +31,7 @@
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
 #include "easynav_sensors/SensorsNode.hpp"
+#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -167,6 +168,8 @@ SensorsNode::get_real_time_cbg()
 bool
 SensorsNode::cycle_rt(bool trigger)
 {
+  EASYNAV_TRACE_EVENT;
+
   (void)trigger;
 
   bool trigger_perceptions = false;
@@ -180,6 +183,8 @@ SensorsNode::cycle_rt(bool trigger)
 void
 SensorsNode::cycle()
 {
+  EASYNAV_TRACE_EVENT;
+
   for (auto & perception : perceptions_) {
     if (perception->valid && (now() - perception->stamp).seconds() > forget_time_) {
       perception->valid = false;


### PR DESCRIPTION
Hi,

This PR completes the Dummy* plugins in easynav. Now their execution time can be controlled via parameters:

```
controller_node:
  ros__parameters:
    use_sim_time: true
    controller_types: [dummy]
    dummy:
      rt_freq: 30.0 
      plugin: easynav_controller/DummyController
      cycle_time_nort: 0.01
      cycle_time_rt: 0.001

localizer_node:
  ros__parameters:
    use_sim_time: true
    localizer_types: [dummy]
    dummy:
      rt_freq: 50.0
      freq: 5.0
      reseed_freq: 0.1
      plugin: easynav_localizer/DummyLocalizer
      cycle_time_nort: 0.01
      cycle_time_rt: 0.001

maps_manager_node:
  ros__parameters:
    use_sim_time: true
    map_types: [dummy]
    dummy:
      freq: 10.0 
      plugin: easynav_maps_manager/DummyMapsManager
      cycle_time_nort: 0.1
      cycle_time_rt: 0.001

planner_node:
  ros__parameters:
    use_sim_time: true
    planner_types: [dummy]
    dummy:
      freq: 1.0
      plugin: easynav_planner/DummyPlanner
      cycle_time_nort: 0.2
      cycle_time_rt: 0.001

sensors_node:
  ros__parameters:
    use_sim_time: true
    forget_time: 0.5

system_node:
  ros__parameters:
    use_sim_time: true
    position_tolerance: 0.1
    angle_tolerance: 0.05
```
