### PR TITLE
Initialize and default dummy cycle times to zero

### DIFF
--- a/easynav_controller/include/easynav_controller/DummyController.hpp
+++ b/easynav_controller/include/easynav_controller/DummyController.hpp
@@ -80,10 +80,10 @@ private:
   /**
    * @brief Current robot velocity command.
    */
-  geometry_msgs::msg::TwistStamped cmd_vel_ {};
+  geometry_msgs::msg::TwistStamped cmd_vel_;
 
-  double cycle_time_rt_;
-  double cycle_time_nort_;
+  double cycle_time_rt_ {0.0};
+  double cycle_time_nort_ {0.0};
 };
 
 }  // namespace easynav

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -33,8 +33,8 @@ std::expected<void, std::string> DummyController::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.01);
-  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.01);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
   node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 

--- a/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
+++ b/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
@@ -82,12 +82,12 @@ public:
 
 private:
   /// @brief Internal odometry placeholder.
-  nav_msgs::msg::Odometry odom_ {};
+  nav_msgs::msg::Odometry odom_;
 
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
-  double cycle_time_rt_;
-  double cycle_time_nort_;
+  double cycle_time_rt_ {0.0};
+  double cycle_time_nort_ {0.0};
 };
 
 }  // namespace easynav

--- a/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
+++ b/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
@@ -33,8 +33,8 @@ std::expected<void, std::string> DummyLocalizer::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.01);
-  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.01);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
   node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 

--- a/easynav_maps_manager/include/easynav_maps_manager/DummyMapsManager.hpp
+++ b/easynav_maps_manager/include/easynav_maps_manager/DummyMapsManager.hpp
@@ -68,8 +68,8 @@ public:
   virtual void update(const NavState & nav_state) override;
 
 private:
-  double cycle_time_rt_;
-  double cycle_time_nort_;
+  double cycle_time_rt_ {0.0};
+  double cycle_time_nort_ {0.0};
 };
 
 }  // namespace easynav

--- a/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
@@ -32,8 +32,8 @@ std::expected<void, std::string> DummyMapsManager::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.01);
-  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.01);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
   node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 

--- a/easynav_planner/include/easynav_planner/DummyPlanner.hpp
+++ b/easynav_planner/include/easynav_planner/DummyPlanner.hpp
@@ -66,10 +66,10 @@ public:
 
 private:
   /// @brief Stored path message (unused in dummy).
-  nav_msgs::msg::Path path_ {};
+  nav_msgs::msg::Path path_;
 
-  double cycle_time_rt_;
-  double cycle_time_nort_;
+  double cycle_time_rt_ {0.0};
+  double cycle_time_nort_ {0.0};
 };
 
 }  // namespace easynav

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -32,8 +32,8 @@ std::expected<void, std::string> DummyPlanner::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.01);
-  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.01);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
+  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
   node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 


### PR DESCRIPTION
Fixes #32.

Cycle times for dummy methods are now initialized to zero.