### PR TITLE
Multi-robot support by namespacing TFs

### DIFF
--- a/easynav_controller/src/easynav_controller/ControllerNode.cpp
+++ b/easynav_controller/src/easynav_controller/ControllerNode.cpp
@@ -88,6 +88,9 @@ ControllerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("controller_types", controller_types);
   get_parameter("controller_types", controller_types);
 
+  std::string tf_namespace;
+  get_parameter("tf_namespace", tf_namespace);
+
   if (controller_types.size() > 1) {
     RCLCPP_ERROR(get_logger(),
       "You must instance one controller.  [%lu] found", controller_types.size());
@@ -105,7 +108,8 @@ ControllerNode::on_configure(const rclcpp_lifecycle::State & state)
 
       controller_method_ = controller_loader_->createSharedInstance(plugin);
 
-      auto result = controller_method_->initialize(shared_from_this(), controller_type);
+      auto result = controller_method_->initialize(shared_from_this(), controller_type,
+        tf_namespace);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_controller/src/easynav_controller/ControllerNode.cpp
+++ b/easynav_controller/src/easynav_controller/ControllerNode.cpp
@@ -88,8 +88,8 @@ ControllerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("controller_types", controller_types);
   get_parameter("controller_types", controller_types);
 
-  std::string tf_namespace;
-  get_parameter("tf_namespace", tf_namespace);
+  std::string tf_prefix;
+  get_parameter("tf_prefix", tf_prefix);
 
   if (controller_types.size() > 1) {
     RCLCPP_ERROR(get_logger(),
@@ -109,7 +109,7 @@ ControllerNode::on_configure(const rclcpp_lifecycle::State & state)
       controller_method_ = controller_loader_->createSharedInstance(plugin);
 
       auto result = controller_method_->initialize(shared_from_this(), controller_type,
-        tf_namespace);
+        tf_prefix);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -40,7 +40,7 @@ std::expected<void, std::string> DummyController::on_initialize()
 
   // Initialize the odometry message
   cmd_vel_.header.stamp = get_node()->now();
-  cmd_vel_.header.frame_id = get_tf_ns() + "base_link";
+  cmd_vel_.header.frame_id = get_tf_prefix() + "base_link";
   cmd_vel_.twist.linear.x = 0.0;
   cmd_vel_.twist.linear.y = 0.0;
   cmd_vel_.twist.linear.z = 0.0;

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -40,7 +40,7 @@ std::expected<void, std::string> DummyController::on_initialize()
 
   // Initialize the odometry message
   cmd_vel_.header.stamp = get_node()->now();
-  cmd_vel_.header.frame_id = "base_link";
+  cmd_vel_.header.frame_id = get_tf_ns() + "base_link";
   cmd_vel_.twist.linear.x = 0.0;
   cmd_vel_.twist.linear.y = 0.0;
   cmd_vel_.twist.linear.z = 0.0;

--- a/easynav_core/include/easynav_core/MethodBase.hpp
+++ b/easynav_core/include/easynav_core/MethodBase.hpp
@@ -59,7 +59,8 @@ public:
   virtual std::expected<void, std::string>
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-    const std::string plugin_name);
+    const std::string & plugin_name,
+    const std::string & tf_namespace = "");
 
   /**
    * @brief Hook for custom setup logic in derived classes.
@@ -87,6 +88,14 @@ public:
   get_plugin_name() const;
 
   /**
+   * @brief Get the TF namespace.
+   *
+   * @return TF namespace with a trailing "/".
+   */
+  [[nodiscard]] const std::string &
+  get_tf_ns() const;
+
+  /**
    * @brief Check whether it is time to run a real-time update.
    *
    * Uses the configured real-time frequency to determine whether sufficient time has elapsed.
@@ -110,6 +119,9 @@ private:
 
   /// @brief Name assigned to the plugin.
   std::string plugin_name_;
+
+  /// @brief TF Namespace.
+  std::string tf_namespace_;
 
   float rt_frequency_, frequency_;
   rclcpp::Time rt_last_ts_, last_ts_;

--- a/easynav_core/include/easynav_core/MethodBase.hpp
+++ b/easynav_core/include/easynav_core/MethodBase.hpp
@@ -60,7 +60,7 @@ public:
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
     const std::string & plugin_name,
-    const std::string & tf_namespace = "");
+    const std::string & tf_prefix = "");
 
   /**
    * @brief Hook for custom setup logic in derived classes.
@@ -93,7 +93,7 @@ public:
    * @return TF namespace with a trailing "/".
    */
   [[nodiscard]] const std::string &
-  get_tf_ns() const;
+  get_tf_prefix() const;
 
   /**
    * @brief Check whether it is time to run a real-time update.
@@ -121,7 +121,7 @@ private:
   std::string plugin_name_;
 
   /// @brief TF Namespace.
-  std::string tf_namespace_;
+  std::string tf_prefix_;
 
   float rt_frequency_, frequency_;
   rclcpp::Time rt_last_ts_, last_ts_;

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -34,12 +34,12 @@ std::expected<void, std::string>
 MethodBase::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
   const std::string & plugin_name,
-  const std::string & tf_namespace
+  const std::string & tf_prefix
 )
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
-  tf_namespace_ = tf_namespace;
+  tf_prefix_ = tf_prefix;
 
   rt_frequency_ = 10.0;
   frequency_ = 10.0;
@@ -68,9 +68,9 @@ MethodBase::get_plugin_name() const
 }
 
 const std::string &
-MethodBase::get_tf_ns() const
+MethodBase::get_tf_prefix() const
 {
-  return tf_namespace_;
+  return tf_prefix_;
 }
 
 bool

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -33,10 +33,13 @@ namespace easynav
 std::expected<void, std::string>
 MethodBase::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-  const std::string plugin_name)
+  const std::string & plugin_name,
+  const std::string & tf_namespace
+)
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
+  tf_namespace_ = tf_namespace;
 
   rt_frequency_ = 10.0;
   frequency_ = 10.0;
@@ -62,6 +65,12 @@ const std::string &
 MethodBase::get_plugin_name() const
 {
   return plugin_name_;
+}
+
+const std::string &
+MethodBase::get_tf_ns() const
+{
+  return tf_namespace_;
 }
 
 bool

--- a/easynav_core/test/core_method_test.cpp
+++ b/easynav_core/test/core_method_test.cpp
@@ -68,7 +68,7 @@ public:
 
   std::expected<void, std::string> on_initialize() override
   {
-    odom_.header.frame_id = get_tf_ns() + "base_link";
+    odom_.header.frame_id = get_tf_prefix() + "base_link";
     odom_.pose.pose.position.x = 5;
 
     return {};

--- a/easynav_core/test/core_method_test.cpp
+++ b/easynav_core/test/core_method_test.cpp
@@ -68,7 +68,7 @@ public:
 
   std::expected<void, std::string> on_initialize() override
   {
-    odom_.header.frame_id = "base_link";
+    odom_.header.frame_id = get_tf_ns() + "base_link";
     odom_.pose.pose.position.x = 5;
 
     return {};

--- a/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
+++ b/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
@@ -50,8 +50,8 @@ void DummyLocalizer::update_rt([[maybe_unused]] NavState & nav_state)
 
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  tf_msg.header.frame_id = get_tf_ns() + "map";
-  tf_msg.child_frame_id = get_tf_ns() + "odom";
+  tf_msg.header.frame_id = get_tf_prefix() + "map";
+  tf_msg.child_frame_id = get_tf_prefix() + "odom";
 
   RTTFBuffer::getInstance()->setTransform(tf_msg, "easynav", false);
   tf_broadcaster_->sendTransform(tf_msg);
@@ -66,8 +66,8 @@ void DummyLocalizer::update([[maybe_unused]] NavState & nav_state)
 
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  tf_msg.header.frame_id = get_tf_ns() + "map";
-  tf_msg.child_frame_id = get_tf_ns() + "odom";
+  tf_msg.header.frame_id = get_tf_prefix() + "map";
+  tf_msg.child_frame_id = get_tf_prefix() + "odom";
 
   RTTFBuffer::getInstance()->setTransform(tf_msg, "easynav", false);
   tf_broadcaster_->sendTransform(tf_msg);

--- a/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
+++ b/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
@@ -50,8 +50,8 @@ void DummyLocalizer::update_rt([[maybe_unused]] NavState & nav_state)
 
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  tf_msg.header.frame_id = "map";
-  tf_msg.child_frame_id = "odom";
+  tf_msg.header.frame_id = get_tf_ns() + "map";
+  tf_msg.child_frame_id = get_tf_ns() + "odom";
 
   RTTFBuffer::getInstance()->setTransform(tf_msg, "easynav", false);
   tf_broadcaster_->sendTransform(tf_msg);
@@ -66,8 +66,8 @@ void DummyLocalizer::update([[maybe_unused]] NavState & nav_state)
 
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  tf_msg.header.frame_id = "map";
-  tf_msg.child_frame_id = "odom";
+  tf_msg.header.frame_id = get_tf_ns() + "map";
+  tf_msg.child_frame_id = get_tf_ns() + "odom";
 
   RTTFBuffer::getInstance()->setTransform(tf_msg, "easynav", false);
   tf_broadcaster_->sendTransform(tf_msg);

--- a/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
+++ b/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
@@ -74,6 +74,9 @@ LocalizerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("localizer_types", localizer_types);
   get_parameter("localizer_types", localizer_types);
 
+  std::string tf_namespace;
+  get_parameter("tf_namespace", tf_namespace);
+
   if (localizer_types.size() > 1) {
     RCLCPP_ERROR(get_logger(),
       "You must instance one localizer.  [%lu] found", localizer_types.size());
@@ -91,7 +94,8 @@ LocalizerNode::on_configure(const rclcpp_lifecycle::State & state)
 
       localizer_method_ = localizer_loader_->createSharedInstance(plugin);
 
-      auto result = localizer_method_->initialize(shared_from_this(), localizer_type);
+      auto result = localizer_method_->initialize(shared_from_this(), localizer_type,
+        tf_namespace);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
+++ b/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
@@ -74,8 +74,8 @@ LocalizerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("localizer_types", localizer_types);
   get_parameter("localizer_types", localizer_types);
 
-  std::string tf_namespace;
-  get_parameter("tf_namespace", tf_namespace);
+  std::string tf_prefix;
+  get_parameter("tf_prefix", tf_prefix);
 
   if (localizer_types.size() > 1) {
     RCLCPP_ERROR(get_logger(),
@@ -95,7 +95,7 @@ LocalizerNode::on_configure(const rclcpp_lifecycle::State & state)
       localizer_method_ = localizer_loader_->createSharedInstance(plugin);
 
       auto result = localizer_method_->initialize(shared_from_this(), localizer_type,
-        tf_namespace);
+        tf_prefix);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
@@ -77,8 +77,8 @@ MapsManagerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("map_types", map_types);
   get_parameter("map_types", map_types);
 
-  std::string tf_namespace;
-  get_parameter("tf_namespace", tf_namespace);
+  std::string tf_prefix;
+  get_parameter("tf_prefix", tf_prefix);
 
   for (const auto & map_type : map_types) {
     std::string plugin;
@@ -92,7 +92,7 @@ MapsManagerNode::on_configure(const rclcpp_lifecycle::State & state)
       std::shared_ptr<MapsManagerBase> instance;
       instance = maps_manager_loader_->createSharedInstance(plugin);
 
-      auto result = instance->initialize(shared_from_this(), map_type, tf_namespace);
+      auto result = instance->initialize(shared_from_this(), map_type, tf_prefix);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
@@ -77,6 +77,9 @@ MapsManagerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("map_types", map_types);
   get_parameter("map_types", map_types);
 
+  std::string tf_namespace;
+  get_parameter("tf_namespace", tf_namespace);
+
   for (const auto & map_type : map_types) {
     std::string plugin;
     declare_parameter(map_type + std::string(".plugin"), plugin);
@@ -89,7 +92,7 @@ MapsManagerNode::on_configure(const rclcpp_lifecycle::State & state)
       std::shared_ptr<MapsManagerBase> instance;
       instance = maps_manager_loader_->createSharedInstance(plugin);
 
-      auto result = instance->initialize(shared_from_this(), map_type);
+      auto result = instance->initialize(shared_from_this(), map_type, tf_namespace);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -39,7 +39,7 @@ std::expected<void, std::string> DummyPlanner::on_initialize()
 
   // Initialize the Path message
   path_.header.stamp = get_node()->now();
-  path_.header.frame_id = get_tf_ns() + "map";
+  path_.header.frame_id = get_tf_prefix() + "map";
   path_.poses.clear();
 
   return {};

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -39,7 +39,7 @@ std::expected<void, std::string> DummyPlanner::on_initialize()
 
   // Initialize the Path message
   path_.header.stamp = get_node()->now();
-  path_.header.frame_id = "map";
+  path_.header.frame_id = get_tf_ns() + "map";
   path_.poses.clear();
 
   return {};

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -75,6 +75,9 @@ PlannerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("planner_types", planner_types);
   get_parameter("planner_types", planner_types);
 
+  std::string tf_namespace;
+  get_parameter("tf_namespace", tf_namespace);
+
   if (planner_types.size() > 1) {
     RCLCPP_ERROR(get_logger(),
       "You must instance one planner.  [%lu] found", planner_types.size());
@@ -92,7 +95,8 @@ PlannerNode::on_configure(const rclcpp_lifecycle::State & state)
 
       planner_method_ = planner_loader_->createSharedInstance(plugin);
 
-      auto result = planner_method_->initialize(shared_from_this(), planner_type);
+      auto result = planner_method_->initialize(shared_from_this(), planner_type,
+        tf_namespace);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -75,8 +75,8 @@ PlannerNode::on_configure(const rclcpp_lifecycle::State & state)
   declare_parameter("planner_types", planner_types);
   get_parameter("planner_types", planner_types);
 
-  std::string tf_namespace;
-  get_parameter("tf_namespace", tf_namespace);
+  std::string tf_prefix;
+  get_parameter("tf_prefix", tf_prefix);
 
   if (planner_types.size() > 1) {
     RCLCPP_ERROR(get_logger(),
@@ -96,7 +96,7 @@ PlannerNode::on_configure(const rclcpp_lifecycle::State & state)
       planner_method_ = planner_loader_->createSharedInstance(plugin);
 
       auto result = planner_method_->initialize(shared_from_this(), planner_type,
-        tf_namespace);
+        tf_prefix);
 
       if (!result) {
         RCLCPP_ERROR(get_logger(),

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -137,6 +137,9 @@ private:
   /// @brief Target frame for perception fusion.
   std::string perception_default_frame_;
 
+  /// @brief TF Namespace
+  std::string tf_namespace_;
+
   std::shared_ptr<NavState> nav_state_;
 
   std::map<std::string, std::vector<PerceptionPtr>> perceptions_;

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -138,7 +138,7 @@ private:
   std::string perception_default_frame_;
 
   /// @brief TF Namespace
-  std::string tf_namespace_;
+  std::string tf_prefix_;
 
   std::shared_ptr<NavState> nav_state_;
 

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -85,6 +85,8 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
   get_parameter("forget_time", forget_time_);
   get_parameter("perception_default_frame", perception_default_frame_);
 
+  get_parameter("tf_namespace", tf_namespace_);
+
   for (const auto & sensor_id : sensors) {
     std::string topic, msg_type, group;
 
@@ -202,12 +204,12 @@ SensorsNode::cycle(std::shared_ptr<NavState> nav_state)
 
   if (percept_pub_->get_subscription_count() > 0) {
     auto fused = PointPerceptionsOpsView(get_point_perceptions(perceptions_["points"]))
-      .fuse(perception_default_frame_);
+      .fuse(tf_namespace_ + perception_default_frame_);
 
     auto fused_points = fused->as_points();
 
     auto msg = points_to_rosmsg(fused_points);
-    msg.header.frame_id = perception_default_frame_;
+    msg.header.frame_id = tf_namespace_ + perception_default_frame_;
     msg.header.stamp = fused->get_perceptions()[0]->stamp;
 
     percept_pub_->publish(msg);

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -85,7 +85,7 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
   get_parameter("forget_time", forget_time_);
   get_parameter("perception_default_frame", perception_default_frame_);
 
-  get_parameter("tf_namespace", tf_namespace_);
+  get_parameter("tf_prefix", tf_prefix_);
 
   for (const auto & sensor_id : sensors) {
     std::string topic, msg_type, group;
@@ -204,12 +204,12 @@ SensorsNode::cycle(std::shared_ptr<NavState> nav_state)
 
   if (percept_pub_->get_subscription_count() > 0) {
     auto fused = PointPerceptionsOpsView(get_point_perceptions(perceptions_["points"]))
-      .fuse(tf_namespace_ + perception_default_frame_);
+      .fuse(tf_prefix_ + perception_default_frame_);
 
     auto fused_points = fused->as_points();
 
     auto msg = points_to_rosmsg(fused_points);
-    msg.header.frame_id = tf_namespace_ + perception_default_frame_;
+    msg.header.frame_id = tf_prefix_ + perception_default_frame_;
     msg.header.stamp = fused->get_perceptions()[0]->stamp;
 
     percept_pub_->publish(msg);

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -74,7 +74,6 @@ SystemNode::SystemNode(const rclcpp::NodeOptions & options)
       return ret;
     });
 
-
   controller_node_ = ControllerNode::make_shared();
   localizer_node_ = LocalizerNode::make_shared();
   maps_manager_node_ = MapsManagerNode::make_shared();
@@ -83,6 +82,8 @@ SystemNode::SystemNode(const rclcpp::NodeOptions & options)
 
   vel_pub_stamped_ = create_publisher<geometry_msgs::msg::TwistStamped>("cmd_vel_stamped", 100);
   vel_pub_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 100);
+
+  declare_parameter<std::string>("tf_namespace", "");
 
   // get_logger().set_level(rclcpp::Logger::Level::Debug);
 }
@@ -107,7 +108,16 @@ SystemNode::on_configure(const rclcpp_lifecycle::State & state)
 {
   (void)state;
 
+  std::string tf_namespace;
+  get_parameter("tf_namespace", tf_namespace);
+  if (tf_namespace != "") {
+    tf_namespace = tf_namespace + "/";
+  }
+
   for (auto & system_node : get_system_nodes()) {
+    system_node.second.node_ptr->declare_parameter<std::string>("tf_namespace", "");
+    system_node.second.node_ptr->set_parameter({"tf_namespace", tf_namespace});
+
     RCLCPP_INFO(get_logger(), "Configuring [%s]", system_node.first.c_str());
     system_node.second.node_ptr->trigger_transition(
       lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -83,7 +83,7 @@ SystemNode::SystemNode(const rclcpp::NodeOptions & options)
   vel_pub_stamped_ = create_publisher<geometry_msgs::msg::TwistStamped>("cmd_vel_stamped", 100);
   vel_pub_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 100);
 
-  declare_parameter<std::string>("tf_namespace", "");
+  declare_parameter<std::string>("tf_prefix", "");
 
   // get_logger().set_level(rclcpp::Logger::Level::Debug);
 }
@@ -108,15 +108,15 @@ SystemNode::on_configure(const rclcpp_lifecycle::State & state)
 {
   (void)state;
 
-  std::string tf_namespace;
-  get_parameter("tf_namespace", tf_namespace);
-  if (tf_namespace != "") {
-    tf_namespace = tf_namespace + "/";
+  std::string tf_prefix;
+  get_parameter("tf_prefix", tf_prefix);
+  if (tf_prefix != "") {
+    tf_prefix = tf_prefix + "/";
   }
 
   for (auto & system_node : get_system_nodes()) {
-    system_node.second.node_ptr->declare_parameter<std::string>("tf_namespace", "");
-    system_node.second.node_ptr->set_parameter({"tf_namespace", tf_namespace});
+    system_node.second.node_ptr->declare_parameter<std::string>("tf_prefix", "");
+    system_node.second.node_ptr->set_parameter({"tf_prefix", tf_prefix});
 
     RCLCPP_INFO(get_logger(), "Configuring [%s]", system_node.first.c_str());
     system_node.second.node_ptr->trigger_transition(


### PR DESCRIPTION
Hi,

This PR adds multi-robot support to EasyNav.

Key points to have in mind:

1. It is better to use a launcher to set namespace and remap TF topic:
```
  easynav_system_cmd = Node(
    package='easynav_system',
    executable='system_main',
    namespace=namespace,
    parameters=[
      params_file
    ],
    remappings=[
            ('/tf', 'tf'),
            ('/tf_static', 'tf_static'),
        ],
  )
```

2. If TFs are namespaced, that is, the frame IDs start with `<namespace>/` (`robot1/base_link` instead of `base_link`), you need to set the `system_node` parameter `tf_namespace`
```
r1/system_node:
  ros__parameters:
    use_sim_time: true
    use_real_time: true
    position_tolerance: 0.1
    angle_tolerance: 0.05
    tf_namespace: r1
```

3. From the developer point of view:
    1. Use `get_fully_qualified_name()` when creating pub/sub/srv in plugins:

```
  static_occ_pub_ = node->create_publisher<nav_msgs::msg::OccupancyGrid>(
    node->get_fully_qualified_name() + std::string("/") + plugin_name + "/map",
    rclcpp::QoS(1).transient_local().reliable());
```
   2. Use `get_tf_ns()` to add TF namespace to frames. If not set, it will be empty. If set, it will contain the namespace with the trailing '/' ('r1/', for example)

``` 
      static_grid_msg_.header.frame_id = get_tf_ns() + "map";
      static_grid_msg_.header.stamp = this->get_node()->now();
```

I hope you like it

