### PR TITLE
Trigger planner if new goals appear

### DIFF
--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -79,7 +79,6 @@ PointPerceptionHandler::create_subscription(
       [target](const sensor_msgs::msg::LaserScan::SharedPtr msg)
       {
         EASYNAV_TRACE_NAMED_EVENT("Lambda::LaserScan");
-
         auto typed_target = std::dynamic_pointer_cast<PointPerception>(target);
 
         convert(*msg, typed_target->data);

--- a/easynav_core/include/easynav_core/MethodBase.hpp
+++ b/easynav_core/include/easynav_core/MethodBase.hpp
@@ -113,6 +113,12 @@ public:
    */
   bool isTime2Run();
 
+  void setRunRT();
+  void setRun();
+
+  const rclcpp::Time & get_last_rt_execution_ts() const {return rt_last_ts_;}
+  const rclcpp::Time & get_last_execution_ts() const {return last_ts_;}
+
 private:
   /// @brief Shared pointer to the parent lifecycle node.
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_ {nullptr};

--- a/easynav_core/include/easynav_core/PlannerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/PlannerMethodBase.hpp
@@ -54,6 +54,13 @@ public:
    */
   void internal_update(NavState & nav_state);
 
+  /**
+   * @brief Helper to run the planner update independently if it is time.
+   *
+   * @param nav_state The current state of the navigation system.
+   */
+  void force_update(NavState & nav_state);
+
 protected:
   /**
    * @brief Run the path planning algorithm and update the route.

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -95,4 +95,16 @@ MethodBase::isTime2Run()
   }
 }
 
+void
+MethodBase::setRunRT()
+{
+  rt_last_ts_ = parent_node_->now();
+}
+
+void
+MethodBase::setRun()
+{
+  last_ts_ = parent_node_->now();
+}
+
 }  // namespace easynav

--- a/easynav_core/src/easynav_core/PlannerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/PlannerMethodBase.cpp
@@ -41,4 +41,11 @@ PlannerMethodBase::internal_update(NavState & nav_state)
   }
 }
 
+void
+PlannerMethodBase::force_update(NavState & nav_state)
+{
+  setRun();
+  update(nav_state);
+}
+
 }  // namespace easynav

--- a/easynav_planner/include/easynav_planner/PlannerNode.hpp
+++ b/easynav_planner/include/easynav_planner/PlannerNode.hpp
@@ -106,8 +106,12 @@ public:
   /**
    * @brief Execute a non-real-time cycle.
    * @param nav_state Shared pointer to the navigation state structure.
+   * @param trigger If tru, a cycle is executed independently of the frequency set
    */
-  void cycle(std::shared_ptr<NavState> nav_state);
+  void cycle(std::shared_ptr<NavState> nav_state, bool trigger = false);
+
+  const rclcpp::Time get_last_rt_execution_ts() const;
+  const rclcpp::Time get_last_execution_ts() const;
 
 private:
   /// @brief Plugin loader for planner methods.

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -154,11 +154,32 @@ PlannerNode::on_error(const rclcpp_lifecycle::State & state)
 }
 
 void
-PlannerNode::cycle(std::shared_ptr<NavState> nav_state)
+PlannerNode::cycle(std::shared_ptr<NavState> nav_state, bool trigger)
 {
   if (planner_method_ == nullptr) {return;}
 
-  planner_method_->internal_update(*nav_state);
+  if (trigger) {
+    planner_method_->force_update(*nav_state);
+  } else {
+    planner_method_->internal_update(*nav_state);
+  }
 }
+
+const rclcpp::Time
+PlannerNode::get_last_rt_execution_ts() const
+{
+  if (planner_method_ == nullptr) {return {};}
+
+  return planner_method_->get_last_rt_execution_ts();
+}
+
+const rclcpp::Time
+PlannerNode::get_last_execution_ts() const
+{
+  if (planner_method_ == nullptr) {return {};}
+
+  return planner_method_->get_last_execution_ts();
+}
+
 
 }  // namespace easynav

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -258,7 +258,11 @@ SystemNode::system_cycle()
   localizer_node_->cycle(nav_state_);
   maps_manager_node_->cycle(nav_state_);
   goal_manager_->update(*nav_state_);
-  planner_node_->cycle(nav_state_);
+
+  rclcpp::Time goals_ts(goal_manager_->get_goals().header.stamp);
+  rclcpp::Time planner_ts = planner_node_->get_last_execution_ts();
+
+  planner_node_->cycle(nav_state_, planner_ts < goals_ts);
 }
 
 std::map<std::string, SystemNodeInfo>


### PR DESCRIPTION
Hi,

This improvement lets the planner execute immediately if new goals appear. Previously, we had to wait until the next iteration cycle, which could take some seconds.

