### PR TITLE
Add operation to include new points in the PointPerceptionView pipeline

### DIFF
--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -217,6 +217,16 @@ public:
   /// \return New fused PointPerceptionsOpsView.
   std::shared_ptr<PointPerceptionsOpsView> fuse(const std::string & target_frame) const;
 
+  /// \brief Add a new Perception from points
+  /// \param points new points to include.
+  /// \param frame Frame ID of the points to add.
+  /// \param stamp Time stamp of the points to add.
+  /// \return New PointPerceptionsOpsView.
+  std::shared_ptr<PointPerceptionsOpsView> add(
+    const pcl::PointCloud<pcl::PointXYZ> points,
+    const std::string & frame,
+    rclcpp::Time stamp) const;
+
   /// \brief Gets a reference to the underlying perceptions container.
   /// \return Constant reference to PointPerceptions.
   const PointPerceptions & get_perceptions() const {return perceptions_;}

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -329,6 +329,25 @@ PointPerceptionsOpsView::fuse(const std::string & target_frame) const
   return std::make_shared<PointPerceptionsOpsView>(std::move(result));
 }
 
+std::shared_ptr<PointPerceptionsOpsView>
+PointPerceptionsOpsView::add(
+  const pcl::PointCloud<pcl::PointXYZ> points,
+  const std::string & frame,
+  rclcpp::Time stamp) const
+{
+  auto new_perception = std::make_shared<PointPerception>();
+  new_perception->valid = true;
+  new_perception->frame_id = frame;
+  new_perception->data = points;
+  new_perception->stamp = stamp;
+
+  PointPerceptions new_perceptions = perceptions_;
+  new_perceptions.push_back(new_perception);
+  auto new_perception_view = std::make_shared<PointPerceptionsOpsView>(std::move(new_perceptions));
+
+  return new_perception_view;
+}
+
 PointPerceptions get_point_perceptions(std::vector<PerceptionPtr> & perceptionptr)
 {
   PointPerceptions ret;


### PR DESCRIPTION
This PR add an `add` operation to `PointPerceptionView`, so you can do:

```
const auto & perceptions = nav_state.get<easynav::PointPerceptions>("points");
  
  pcl::PointCloud<pcl::PointXYZ> base_floor;
  for (float x = -platform_area_; x < platform_area_; x = x + resolution_ / 2.0) {
    for (float y = -platform_area_; y < platform_area_; y = y + resolution_ / 2.0) {
      base_floor.push_back({x, y, 0.0});
    }
  }


  auto fused = easynav::PointPerceptionsOpsView(perceptions)
    .add(base_floor, frame_id_, get_node()->now())
    ->downsample(resolution_)
    .fuse(get_tf_prefix() + frame_id_)
    ->filter({-radious_, -radious_, NAN}, {radious_, radious_, 2.0})
    .as_points();
```