### PR TITLE
Fix tf2_ros deprecation warnings and remove warnings from unused parameters

### DIFF
--- a/easynav_common/include/easynav_common/RTTFBuffer.hpp
+++ b/easynav_common/include/easynav_common/RTTFBuffer.hpp
@@ -23,7 +23,7 @@
 
 #include "easynav_common/Singleton.hpp"
 
-#include "tf2_ros/buffer.h"
+#include "tf2_ros/buffer.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 namespace easynav

--- a/easynav_common/tests/perceptions_tests.cpp
+++ b/easynav_common/tests/perceptions_tests.cpp
@@ -33,7 +33,7 @@
 #include "pcl_conversions/pcl_conversions.h"
 #include "pcl/point_types_conversion.h"
 #include "pcl/common/transforms.h"
-#include "tf2_ros/transform_broadcaster.h"
+#include "tf2_ros/transform_broadcaster.hpp"
 #include "tf2/transform_datatypes.hpp"
 
 #include "gtest/gtest.h"

--- a/easynav_common/tests/pointperceptionsops_tests.cpp
+++ b/easynav_common/tests/pointperceptionsops_tests.cpp
@@ -23,8 +23,8 @@
 #include <vector>
 #include <cmath>
 
-#include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/buffer.hpp"
+#include "tf2_ros/transform_listener.hpp"
 
 #include "easynav_common/types/PointPerception.hpp"
 #include "easynav_common/RTTFBuffer.hpp"

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -51,7 +51,7 @@ std::expected<void, std::string> DummyController::on_initialize()
   return {};
 }
 
-void DummyController::update_rt(NavState & nav_state)
+void DummyController::update_rt([[maybe_unused]] NavState & nav_state)
 {
   auto start = get_node()->now();
   while ((get_node()->now() - start).seconds() < cycle_time_rt_) {}

--- a/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
+++ b/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
@@ -27,7 +27,7 @@
 
 #include "nav_msgs/msg/odometry.hpp"
 #include "easynav_core/LocalizerMethodBase.hpp"
-#include "tf2_ros/transform_broadcaster.h"
+#include "tf2_ros/transform_broadcaster.hpp"
 
 namespace easynav
 {

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -45,7 +45,7 @@ std::expected<void, std::string> DummyPlanner::on_initialize()
   return {};
 }
 
-void DummyPlanner::update(NavState & nav_state)
+void DummyPlanner::update([[maybe_unused]] NavState & nav_state)
 {
   auto start = get_node()->now();
   while ((get_node()->now() - start).seconds() < cycle_time_nort_) {}

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -168,7 +168,7 @@ PlannerNode::cycle(std::shared_ptr<NavState> nav_state, bool trigger)
 const rclcpp::Time
 PlannerNode::get_last_rt_execution_ts() const
 {
-  if (planner_method_ == nullptr) {return {};}
+  if (planner_method_ == nullptr) {return rclcpp::Time();}
 
   return planner_method_->get_last_rt_execution_ts();
 }
@@ -176,7 +176,7 @@ PlannerNode::get_last_rt_execution_ts() const
 const rclcpp::Time
 PlannerNode::get_last_execution_ts() const
 {
-  if (planner_method_ == nullptr) {return {};}
+  if (planner_method_ == nullptr) {return rclcpp::Time();}
 
   return planner_method_->get_last_execution_ts();
 }

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -27,8 +27,8 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-#include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/buffer.hpp"
+#include "tf2_ros/transform_listener.hpp"
 
 #include "sensor_msgs/msg/point_cloud2.hpp"
 

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -56,7 +56,8 @@ namespace
 static std::unordered_map<std::string, std::string> g_group_alias;
 }
 
-inline std::string resolve_group_from_msg(std::string_view msg_type, std::true_type)
+inline std::string
+resolve_group_from_msg([[maybe_unused]] std::string_view msg_type, std::true_type)
 {
   return {};
 }

--- a/easynav_sensors/tests/sensors_node_tests.cpp
+++ b/easynav_sensors/tests/sensors_node_tests.cpp
@@ -32,7 +32,8 @@
 #include "pcl_conversions/pcl_conversions.h"
 #include "pcl/point_types_conversion.h"
 #include "pcl/common/transforms.h"
-#include "tf2_ros/transform_broadcaster.h"
+#include "tf2_ros/transform_broadcaster.hpp"
+#include "tf2_ros/transform_listener.hpp"
 #include "tf2/transform_datatypes.hpp"
 
 #include "gtest/gtest.h"
@@ -412,7 +413,7 @@ TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
     });
 
   auto tf_buffer = easynav::RTTFBuffer::getInstance(test_node->get_clock());
-  tf2_ros::TransformListener tf_listener(*tf_buffer, test_node, true);
+  tf2_ros::TransformListener tf_listener(*tf_buffer, *test_node, true);
 
   auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*test_node);
   geometry_msgs::msg::TransformStamped transform;

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -228,9 +228,6 @@ SystemNode::system_cycle_rt()
   bool trigger_localization = localizer_node_->cycle_rt(nav_state_, trigger_perceptions);
 
   bool trigger_controller = false;
-  bool robot_idle_stop = true;
-
-  const auto navigation_state = nav_state_->get<GoalManager::State>("navigation_state");
 
   bool trigger = trigger_perceptions || trigger_localization;
   trigger_controller = controller_node_->cycle_rt(nav_state_, trigger);

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char ** argv)
         RCLCPP_INFO(system_node->get_logger(), "Selected NO Real-Time");
       }
 
-      tf2_ros::TransformListener tf_listener(*tf_buffer, tf_node, true);
+      tf2_ros::TransformListener tf_listener(*tf_buffer, *tf_node, true);
 
       rclcpp::Rate rate(100);
       while (rclcpp::ok()) {


### PR DESCRIPTION
Simple cleanup to avoid some warning messages during compilation:

* Using `.hpp` headers for `tf2_ros` stuff instead of `.h` (deprecated) headers. Should work at least up to jazzy.
* Added `[[maybe_unused]]` attribute to parameters in some methods that do not use them, but cannot be removed from the interface.
* Removed a couple of dangling local unused variables in the SystemNode code.