### PR TITLE
Fix block

### DIFF
--- a/easynav_system/include/easynav_system/SystemNode.hpp
+++ b/easynav_system/include/easynav_system/SystemNode.hpp
@@ -142,9 +142,6 @@ private:
   /// @brief Real-time callback group.
   rclcpp::CallbackGroup::SharedPtr realtime_cbg_;
 
-  /// @brief Timer for non-real-time updates.
-  rclcpp::TimerBase::SharedPtr system_main_nort_timer_;
-
   /// @brief Controller node.
   ControllerNode::SharedPtr controller_node_;
 

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -162,8 +162,6 @@ SystemNode::on_activate(const rclcpp_lifecycle::State & state)
     }
   }
 
-  // system_main_nort_timer_ = create_wall_timer(30ms, std::bind(&SystemNode::system_cycle, this));
-
   return CallbackReturnT::SUCCESS;
 }
 
@@ -184,8 +182,6 @@ SystemNode::on_deactivate(const rclcpp_lifecycle::State & state)
       return CallbackReturnT::FAILURE;
     }
   }
-
-  // system_main_nort_timer_->cancel();
 
   return CallbackReturnT::SUCCESS;
 }

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -162,7 +162,7 @@ SystemNode::on_activate(const rclcpp_lifecycle::State & state)
     }
   }
 
-  system_main_nort_timer_ = create_timer(30ms, std::bind(&SystemNode::system_cycle, this));
+  // system_main_nort_timer_ = create_wall_timer(30ms, std::bind(&SystemNode::system_cycle, this));
 
   return CallbackReturnT::SUCCESS;
 }
@@ -185,7 +185,7 @@ SystemNode::on_deactivate(const rclcpp_lifecycle::State & state)
     }
   }
 
-  system_main_nort_timer_->cancel();
+  // system_main_nort_timer_->cancel();
 
   return CallbackReturnT::SUCCESS;
 }

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -69,13 +69,17 @@ int main(int argc, char ** argv)
 
     // Lifecycle: configure -> activate
     system_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
-    if (system_node->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+    if (system_node->get_current_state().id() !=
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+    {
       RCLCPP_ERROR(system_node->get_logger(), "Unable to configure EasyNav");
       rclcpp::shutdown();
       return 1;
     }
     system_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
-    if (system_node->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    if (system_node->get_current_state().id() !=
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    {
       RCLCPP_ERROR(system_node->get_logger(), "Unable to activate EasyNav");
       rclcpp::shutdown();
       return 1;
@@ -116,8 +120,8 @@ int main(int argc, char ** argv)
           {
             system_node->system_cycle_rt();
           }
-          exe_rt.spin_some(std::chrono::milliseconds(1));  // steady timeout
-          rate.sleep();                                    // steady clock
+          exe_rt.spin_some(std::chrono::milliseconds(1));
+          rate.sleep();
         }
       });
 
@@ -131,8 +135,8 @@ int main(int argc, char ** argv)
         system_node->system_cycle();
       }
 
-      exe_nort.spin_some(std::chrono::milliseconds(1));    // steady timeout
-      rate.sleep();                                        // steady clock
+      exe_nort.spin_some(std::chrono::milliseconds(1));
+      rate.sleep();
     }
 
     // Ensure stop flag visible and cancel executors (idempotent)
@@ -140,19 +144,13 @@ int main(int argc, char ** argv)
     exe_rt.cancel();
     exe_nort.cancel();
 
-    // Executors, nodes, and callback groups will be destroyed when leaving this scope,
-    // after rt_thread has been joined below.
-    // Do NOT call remove_* here; destruction order is handled by scope exit.
-    // Keep shared_ptrs (system_node, tf_node) alive until after rt_thread.join().
-    // They will be destroyed after we exit this block.
-  } // end executors scope (but we still must join the RT thread before rclcpp::shutdown)
+  
 
   // Wait the RT thread to finish before shutting down ROS.
   if (rt_thread.joinable()) {
     rt_thread.join();
   }
 
-  // Finally, shutdown the ROS context.
   rclcpp::shutdown();
   return 0;
 }

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -143,7 +143,7 @@ int main(int argc, char ** argv)
     stop.store(true, std::memory_order_relaxed);
     exe_rt.cancel();
     exe_nort.cancel();
-
+  }
   
 
   // Wait the RT thread to finish before shutting down ROS.

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -91,9 +91,9 @@ int main(int argc, char ** argv)
 
     // Cooperative shutdown on SIGINT
     rclcpp::on_shutdown([&](){
-      stop.store(true, std::memory_order_relaxed);
-      exe_rt.cancel();
-      exe_nort.cancel();
+        stop.store(true, std::memory_order_relaxed);
+        exe_rt.cancel();
+        exe_nort.cancel();
     });
 
     // RT thread
@@ -116,7 +116,7 @@ int main(int argc, char ** argv)
         rclcpp::WallRate rate(100);
         while (!stop.load(std::memory_order_relaxed)) {
           if (system_node->get_current_state().id() ==
-              lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+          lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
           {
             system_node->system_cycle_rt();
           }
@@ -144,7 +144,7 @@ int main(int argc, char ** argv)
     exe_rt.cancel();
     exe_nort.cancel();
   }
-  
+
 
   // Wait the RT thread to finish before shutting down ROS.
   if (rt_thread.joinable()) {

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -17,14 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 #include <string>
+#include <atomic>
+#include <thread>
+#include <chrono>
 
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "easynav_system/SystemNode.hpp"
-
 #include "easynav_common/RTTFBuffer.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -36,85 +37,122 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  rclcpp::experimental::executors::EventsExecutor exe_nort, exe_rt;
-  auto system_node = easynav::SystemNode::make_shared();
+  std::atomic_bool stop{false};
 
-  exe_nort.add_node(system_node->get_node_base_interface());
-  exe_rt.add_callback_group(system_node->get_real_time_cbg(),
-    system_node->get_node_base_interface());
+  std::thread rt_thread;
+  {
+    // Executors live in this scope and will be destroyed after join().
+    rclcpp::executors::SingleThreadedExecutor exe_nort;
+    rclcpp::executors::SingleThreadedExecutor exe_rt;
 
-  auto tf_node = rclcpp::Node::make_shared("tf_node");
-  exe_rt.add_node(tf_node);
+    auto system_node = easynav::SystemNode::make_shared();
 
-  auto tf_buffer = easynav::RTTFBuffer::getInstance(tf_node->get_clock());
+    exe_nort.add_node(system_node->get_node_base_interface());
+    exe_rt.add_callback_group(system_node->get_real_time_cbg(),
+                              system_node->get_node_base_interface());
 
-  for (auto & node : system_node->get_system_nodes()) {
-    exe_nort.add_node(node.second.node_ptr->get_node_base_interface());
-    if (node.second.realtime_cbg != nullptr) {
-      exe_rt.add_callback_group(node.second.realtime_cbg,
-        node.second.node_ptr->get_node_base_interface());
+    // TF on steady/wall time, independent from /clock.
+    auto tf_node = rclcpp::Node::make_shared("tf_node");
+    tf_node->set_parameter(rclcpp::Parameter("use_sim_time", false));
+    exe_rt.add_node(tf_node);
+
+    auto tf_clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+    auto tf_buffer = easynav::RTTFBuffer::getInstance(tf_clock);
+
+    for (auto & node : system_node->get_system_nodes()) {
+      exe_nort.add_node(node.second.node_ptr->get_node_base_interface());
+      if (node.second.realtime_cbg != nullptr) {
+        exe_rt.add_callback_group(node.second.realtime_cbg,
+                                  node.second.node_ptr->get_node_base_interface());
+      }
     }
-  }
 
-  system_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
-  if (system_node->get_current_state().id() !=
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-  {
-    RCLCPP_ERROR(system_node->get_logger(), "Unable to configure EasyNav");
-    rclcpp::shutdown();
-    return 1;
-  }
-  system_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
-  if (system_node->get_current_state().id() !=
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
-  {
-    RCLCPP_ERROR(system_node->get_logger(), "Unable to activate EasyNav");
-    rclcpp::shutdown();
-    return 1;
-  }
+    // Lifecycle: configure -> activate
+    system_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+    if (system_node->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+      RCLCPP_ERROR(system_node->get_logger(), "Unable to configure EasyNav");
+      rclcpp::shutdown();
+      return 1;
+    }
+    system_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+    if (system_node->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+      RCLCPP_ERROR(system_node->get_logger(), "Unable to activate EasyNav");
+      rclcpp::shutdown();
+      return 1;
+    }
 
-  bool use_real_time = true;
-  system_node->declare_parameter("use_real_time", use_real_time);
-  system_node->get_parameter("use_real_time", use_real_time);
+    bool use_real_time = true;
+    system_node->declare_parameter("use_real_time", use_real_time);
+    system_node->get_parameter("use_real_time", use_real_time);
 
-  auto rt_thread = std::thread(
-    [&]() {
-      if (use_real_time) {
-        RCLCPP_INFO(system_node->get_logger(), "Selected Real-Time");
-        sched_param sch;
-        sch.sched_priority = 80;
-
-        if (sched_setscheduler(0, SCHED_FIFO, &sch) == -1) {
-          RCLCPP_WARN(
-            system_node->get_logger(),
-            "Failed to tet EasyNav to execute in Real Time.");
-          RCLCPP_WARN(system_node->get_logger(), "set your system to have permissions.");
-          RCLCPP_WARN(system_node->get_logger(), "Running RT Thread with normal priority.");
-        }
-      } else {
-        RCLCPP_INFO(system_node->get_logger(), "Selected NO Real-Time");
-      }
-
-      tf2_ros::TransformListener tf_listener(*tf_buffer, tf_node, true);
-
-      rclcpp::Rate rate(100);
-      while (rclcpp::ok()) {
-        if (system_node->get_current_state().id() ==
-        lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
-        {
-          system_node->system_cycle_rt();
-        }
-        rate.sleep();
-        exe_rt.spin_some();
-      }
+    // Cooperative shutdown on SIGINT
+    rclcpp::on_shutdown([&](){
+      stop.store(true, std::memory_order_relaxed);
+      exe_rt.cancel();
+      exe_nort.cancel();
     });
 
-  exe_nort.spin();
+    // RT thread
+    rt_thread = std::thread(
+      [&, tf_node, tf_buffer, system_node, use_real_time]() {
+        if (use_real_time) {
+          RCLCPP_INFO(system_node->get_logger(), "Selected Real-Time");
+          sched_param sch; sch.sched_priority = 80;
+          if (sched_setscheduler(0, SCHED_FIFO, &sch) == -1) {
+            RCLCPP_WARN(system_node->get_logger(),
+              "Failed to set Real Time. Running with normal priority.");
+          }
+        } else {
+          RCLCPP_INFO(system_node->get_logger(), "Selected NO Real-Time");
+        }
 
-  rt_thread.join();
+        // No dedicated spin thread; TF uses exe_rt.
+        tf2_ros::TransformListener tf_listener(*tf_buffer, tf_node, /*spin_thread=*/false);
 
-  // TODO: There is an issue here to cleanly finish https://github.com/ros2/rclcpp/issues/2520
+        rclcpp::WallRate rate(100);
+        while (!stop.load(std::memory_order_relaxed)) {
+          if (system_node->get_current_state().id() ==
+              lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+          {
+            system_node->system_cycle_rt();
+          }
+          exe_rt.spin_some(std::chrono::milliseconds(1));  // steady timeout
+          rate.sleep();                                    // steady clock
+        }
+      });
 
+    // Non-RT loop
+    rclcpp::WallRate rate(100);
+    while (!stop.load(std::memory_order_relaxed)) {
+
+      if (system_node->get_current_state().id() ==
+        lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+      {
+        system_node->system_cycle();
+      }
+
+      exe_nort.spin_some(std::chrono::milliseconds(1));    // steady timeout
+      rate.sleep();                                        // steady clock
+    }
+
+    // Ensure stop flag visible and cancel executors (idempotent)
+    stop.store(true, std::memory_order_relaxed);
+    exe_rt.cancel();
+    exe_nort.cancel();
+
+    // Executors, nodes, and callback groups will be destroyed when leaving this scope,
+    // after rt_thread has been joined below.
+    // Do NOT call remove_* here; destruction order is handled by scope exit.
+    // Keep shared_ptrs (system_node, tf_node) alive until after rt_thread.join().
+    // They will be destroyed after we exit this block.
+  } // end executors scope (but we still must join the RT thread before rclcpp::shutdown)
+
+  // Wait the RT thread to finish before shutting down ROS.
+  if (rt_thread.joinable()) {
+    rt_thread.join();
+  }
+
+  // Finally, shutdown the ROS context.
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
Hi,

This PR started as a try to avoid getting stuck when stopping the process, but in some cases, it is still stuck.

I want to merge this because the key here is that the non-RT cycle **shouldn't** be governed by a timer, because if any plugin takes too much time, no callbacks will be managed; only the timer, because it has more priority to be executed than messages. This bad situation was detected using a high-expense process in localization plugins, and this means that no messages are managed, for example,  new goals.

I am merging this to jazzy instead of rolling because we want to fix everything in LTS (jazzy) before propagating to other branches.

I hope this helps.