### PR TITLE
Add missing dependencies

### DIFF
--- a/easynav_common/package.xml
+++ b/easynav_common/package.xml
@@ -28,6 +28,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>yaets</depend>
+  <depend>cv_bridge</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/easynav_tools/package.xml
+++ b/easynav_tools/package.xml
@@ -24,6 +24,8 @@
   <exec_depend>easynav_support_py</exec_depend>
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>python3-rich</exec_depend>
+  <exec_depend>python3-typing-extensions</exec_depend>
+  <exec_depend>python3-platformdirs</exec_depend>
 
   <!-- Test and launch deps -->
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
Fixed some errors about missing dependencies in the TUI and `easynav_common`.

* For the TUI, the `textual` package is now vendored, so its dependencies must be installed via apt (python3-<module> packages).
* In `easynav_common`, the `cv_bridge` dependency was missing in the `package.xml`. This one is easy to miss since most of us already have it installed in our system, but it was causing colcon to fail in a clean docker installation.


Note: Merging this to the jazzy branch for now, but this should be propagated to kilted and rolling.