### PR TITLE
GoalManager: Split position tolerance into x/y and height

### DIFF
--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -62,6 +62,20 @@ public:
   };
 
   /**
+   * @struct GoalTolerance
+   * @brief A structure to represent the goal tolerances.
+   */
+  struct GoalTolerance
+  {
+    /// Positional tolerance for x/y in meters.
+    double position {0.03};
+    /// Positional tolerance for z axis in meters. Very big number as default.
+    double height {std::numeric_limits<double>::max()};
+    /// Angular tolerance in radians for the yaw angle.
+    double yaw {0.01};
+  };
+
+  /**
    * @brief Constructor.
    * @param nav_state Shared pointer to navigation state.
    * @param parent_node Lifecycle node for parameter and interface management.
@@ -111,42 +125,19 @@ public:
    * positional and angular tolerances.
    *
    * @param current_pose Current pose of the robot.
-   * @param position_tolerance Maximum allowed positional error (meters).
-   * @param angle_tolerance Maximum allowed angular error (radians).
+   * @param goal_tolerance Maximum allowed error for the goal position and orientation.
    */
   void check_goals(
     const geometry_msgs::msg::Pose & current_pose,
-    double position_tolerance, double angle_tolerance);
-
-  /**
-   * @brief Get Distance between two poses
-   *
-   * @param pose1 First pose
-   * @param pose2 Second pose
-   */
-  double calculate_distance(
-    const geometry_msgs::msg::Pose & pose1,
-    const geometry_msgs::msg::Pose & pose2);
-
-  /**
-   * @brief Get Distance between two poses
-   *
-   * @param pose1 First pose
-   * @param pose2 Second pose
-   */
-  double calculate_angle(
-    const geometry_msgs::msg::Pose & pose1,
-    const geometry_msgs::msg::Pose & pose2);
+    const GoalTolerance & goal_tolerance
+  );
 
 private:
   /// @brief Lifecycle node.
   rclcpp_lifecycle::LifecycleNode::SharedPtr parent_node_;
 
-  /// @brief Positional tolerance in meters.
-  double position_tolerance_ {0.03};
-
-  /// @brief Angular tolerance in radians.
-  double angle_tolerance_ {0.01};
+  /// @brief Goal tolerance (translation and rotation).
+  GoalTolerance goal_tolerance_ {};
 
   /// @brief Currently active goals.
   nav_msgs::msg::Goals goals_;

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -20,13 +20,55 @@
 /// \file
 /// \brief Implementation of the GoalManager class.
 
+#include <numbers>
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2/utils.hpp"
 #include "easynav_system/GoalManager.hpp"
 
 #include "nav_msgs/msg/odometry.hpp"
 
 namespace easynav
 {
+
+/** Internal utility functions */
+/**
+  * @brief Get the x/y distance between two poses
+  *
+  * @param pose1 First pose
+  * @param pose2 Second pose
+  */
+double calculate_distance_xy(
+  const geometry_msgs::msg::Pose & pose1,
+  const geometry_msgs::msg::Pose & pose2)
+{
+  const double dx = pose1.position.x - pose2.position.x;
+  const double dy = pose1.position.y - pose2.position.y;
+  return std::hypot(dx, dy);
+}
+
+/** Angle normalization to [-pi, pi) range (in radians) */
+constexpr double norm_angle(const double angle)
+{
+  using std::numbers::pi;
+  double norm_angle = std::fmod(angle + pi, 2 * pi);
+  return norm_angle < 0 ? norm_angle + pi : norm_angle - pi;
+}
+
+/**
+  * @brief Get the (absolute) yaw angle difference between two poses
+  *
+  * @param pose1 First pose
+  * @param pose2 Second pose
+  */
+double calculate_angle(
+  const geometry_msgs::msg::Pose & pose1,
+  const geometry_msgs::msg::Pose & pose2)
+{
+  const double yaw1 = tf2::getYaw(pose1.orientation);
+  const double yaw2 = tf2::getYaw(pose2.orientation);
+  return norm_angle(yaw1 - yaw2);
+}
+
 
 GoalManager::GoalManager(
   NavState & nav_state,
@@ -36,11 +78,13 @@ GoalManager::GoalManager(
   nav_state.set("navigation_state", state_);
 
   parent_node_->declare_parameter("allow_preempt_goal", allow_preempt_goal_);
-  parent_node_->declare_parameter("position_tolerance", position_tolerance_);
-  parent_node_->declare_parameter("angle_tolerance", angle_tolerance_);
+  parent_node_->declare_parameter("position_tolerance", goal_tolerance_.position);
+  parent_node_->declare_parameter("height_tolerance", goal_tolerance_.height);
+  parent_node_->declare_parameter("angle_tolerance", goal_tolerance_.yaw);
   parent_node_->get_parameter("allow_preempt_goal", allow_preempt_goal_);
-  parent_node_->get_parameter("position_tolerance", position_tolerance_);
-  parent_node_->get_parameter("angle_tolerance", angle_tolerance_);
+  parent_node_->get_parameter("position_tolerance", goal_tolerance_.position);
+  parent_node_->get_parameter("height_tolerance", goal_tolerance_.height);
+  parent_node_->get_parameter("angle_tolerance", goal_tolerance_.yaw);
 
   control_sub_ = parent_node_->create_subscription<easynav_interfaces::msg::NavigationControl>(
     "easynav_control", 100,
@@ -293,18 +337,16 @@ GoalManager::update(NavState & nav_state)
   feedback.navigation_time = parent_node_->now() - nav_start_time_;
 
   const auto & first_goal = goals_.goals.front().pose;
-  feedback.distance_to_goal = calculate_distance(robot_pose, first_goal);
+  feedback.distance_to_goal = calculate_distance_xy(robot_pose, first_goal);
 
-  // ToDo[@fmrico]: Complete feedback info
+  // ToDo[@fmrico]: Complete feedback info: estimated_time_remaining and distance_covered
 
   RCLCPP_DEBUG(parent_node_->get_logger(), "Sending navigation feedback");
 
   control_pub_->publish(feedback);
   *last_control_ = feedback;
 
-  check_goals(
-    robot_pose,
-    position_tolerance_, angle_tolerance_);
+  check_goals(robot_pose, goal_tolerance_);
 
   if (!nav_state.has("goals") || nav_state.get<nav_msgs::msg::Goals>("goals") != goals_) {
     nav_state.set("goals", goals_);
@@ -322,8 +364,8 @@ GoalManager::update(NavState & nav_state)
     easynav_interfaces::msg::GoalManagerInfo msg;
     msg.status = static_cast<int>(get_state());
     msg.goals = get_goals();
-    msg.position_tolerance = position_tolerance_;
-    msg.angle_tolerance = angle_tolerance_;
+    msg.position_tolerance = goal_tolerance_.position;
+    msg.angle_tolerance = goal_tolerance_.yaw;
     msg.position_distance = feedback.distance_to_goal;
     msg.angle_distance = calculate_angle(robot_pose, first_goal);
     info_pub_->publish(msg);
@@ -333,50 +375,24 @@ GoalManager::update(NavState & nav_state)
 void
 GoalManager::check_goals(
   const geometry_msgs::msg::Pose & current_pose,
-  double position_tolerance, double angle_tolerance)
+  const GoalTolerance & goal_tolerance)
 {
   if (goals_.goals.empty()) {return;}
 
   const auto & first_goal = goals_.goals.front().pose;
 
-  double distance = calculate_distance(current_pose, first_goal);
+  const double distance_xy = calculate_distance_xy(current_pose, first_goal);
+  const double distance_z = std::abs(current_pose.position.z - first_goal.position.z);
 
-  if (distance > position_tolerance) {
+  if (distance_xy > goal_tolerance.position || distance_z > goal_tolerance.height) {
     return;
   }
 
-  double angle_diff = calculate_angle(current_pose, first_goal);
+  const double angle_diff = calculate_angle(current_pose, first_goal);
 
-  if (angle_diff <= angle_tolerance) {
+  if (angle_diff <= goal_tolerance.yaw) {
     goals_.goals.erase(goals_.goals.begin());
   }
-}
-
-double
-GoalManager::calculate_distance(
-  const geometry_msgs::msg::Pose & pose1,
-  const geometry_msgs::msg::Pose & pose2)
-{
-  double dx = pose1.position.x - pose2.position.x;
-  double dy = pose1.position.y - pose2.position.y;
-  double dz = pose1.position.z - pose2.position.z;
-  double distance = std::sqrt(dx * dx + dy * dy + dz * dz);
-
-  return distance;
-}
-
-double
-GoalManager::calculate_angle(
-  const geometry_msgs::msg::Pose & pose1,
-  const geometry_msgs::msg::Pose & pose2)
-{
-  tf2::Quaternion q_current, q_goal;
-  tf2::fromMsg(pose1.orientation, q_current);
-  tf2::fromMsg(pose2.orientation, q_goal);
-
-  double angle_diff = q_current.angleShortestPath(q_goal);
-
-  return angle_diff;
 }
 
 }  // namespace easynav


### PR DESCRIPTION
Hi,

This PR tries to temporarily fix an issue with 2D goals in 3D environments:

Right now, the position tolerance accounts for the `(x, y, z)` distance. The problem arises when using Rviz "2D Goal Pose" button, which publishes a goal with `z = 0`. Because we are computing the 3D distance, it is impossible to reach the goal on elevated terrains.

I have created a new parameter for the `height_tolerance`. This is defaulted to infinity so current 2D applications do not need to specify it. In addition, now the semantics of the `position_tolerance` parameter have changed: It represents the position in the c/y plane.

Furthermore, the angle tolerance has the same issue. It is estimating the angle combining roll, pitch and yaw, so it may cause trouble if the goal is on a surface with some inclination. The parameter now represents the tolerance only in the yaw angle, and the goal checking has been updated accordingly.

Note: I have not updated the feedback messages or the TUI, but it can be done in the future. Now the `distance_to_goal` feedback represents only the distance in the c/y plane.

Note 2: In the future we should consider a different representation/mechanism for the tolerances, so we can work in 2D and 3D without dirty fixes. Perhaps the goals for 3D environments should not come from the "2D Goal Pose" button in Rviz.

Have a nice weekend!