### PR TITLE
Fix TF compilation warnings

### DIFF
--- a/easynav_sensors/tests/sensors_node_tests.cpp
+++ b/easynav_sensors/tests/sensors_node_tests.cpp
@@ -413,7 +413,7 @@ TEST_F(SensorsNodeTestCase, percept_fuse_laserscan)
     });
 
   auto tf_buffer = easynav::RTTFBuffer::getInstance(test_node->get_clock());
-  tf2_ros::TransformListener tf_listener(*tf_buffer, test_node, true);
+  tf2_ros::TransformListener tf_listener(*tf_buffer, *test_node, true);
 
   auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*test_node);
   geometry_msgs::msg::TransformStamped transform;

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char ** argv)
         }
 
         // No dedicated spin thread; TF uses exe_rt.
-        tf2_ros::TransformListener tf_listener(*tf_buffer, tf_node, /*spin_thread=*/false);
+        tf2_ros::TransformListener tf_listener(*tf_buffer, *tf_node, /*spin_thread=*/false);
 
         rclcpp::WallRate rate(100);
         while (!stop.load(std::memory_order_relaxed)) {


### PR DESCRIPTION
This PR fixes some compilation warnings about a deprecated API in the tf2 library.