### PR TITLE
Fix errors in periodic CI

### DIFF
--- a/.github/workflows/humble.yaml
+++ b/.github/workflows/humble.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: humble
+          ref: humble
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/jazzy.yaml
+++ b/.github/workflows/jazzy.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: jazzy
+          ref: jazzy
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/kilted.yaml
+++ b/.github/workflows/kilted.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: kilted
+          ref: kilted
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: rolling
+          ref: rolling
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {


### PR DESCRIPTION
Hi,

The periodic CI is failing every Saturday on all branches except rolling. This is because the `action-ros-ci` action is pulling by default the main branch (rolling) when building.

I just added the `ref` parameter so each build is using the appropriate branch.

Best. 