### PR TITLE
Allow using yaets tracing macros from outside the easynav namespace

### DIFF
--- a/easynav_common/include/easynav_common/YTSession.hpp
+++ b/easynav_common/include/easynav_common/YTSession.hpp
@@ -47,15 +47,15 @@ public:
   SINGLETON_DEFINITIONS(YTSession)
 };
 
+}  // namespace easynav
+
 #ifdef EASYNAV_DEBUG_WITH_YAETS
-  #define EASYNAV_TRACE_EVENT TRACE_EVENT(YTSession::get())
-  #define EASYNAV_TRACE_NAMED_EVENT(name) yaets::TraceGuard guard(YTSession::get(), name);
+  #define EASYNAV_TRACE_EVENT TRACE_EVENT(easynav::YTSession::get())
+  #define EASYNAV_TRACE_NAMED_EVENT(name) yaets::TraceGuard guard(easynav::YTSession::get(), name);
 #else
   #define EASYNAV_TRACE_EVENT ((void)0)
   #define EASYNAV_TRACE_NAMED_EVENT(name) ((void)0)
 #endif
-
-}  // namespace easynav
 
 
 #endif  // EASYNAV_COMMON_TYPES__YTSESSION_HPP_


### PR DESCRIPTION
Macros do not care about scope. The tracing macro `EASYNAV_TRACE_EVENT` was asuming the caller code was inside the `easynav` namespace, and was not usable from code outside the namespace.

This PR specifically adds the `easynav` namespace to the `YTSession` in the yaets macros, so they can be used from anywhere.