### PR TITLE
Reshape execution and sensor handling

### DIFF
--- a/easynav_common/include/easynav_common/types/GNSSPerception.hpp
+++ b/easynav_common/include/easynav_common/types/GNSSPerception.hpp
@@ -88,7 +88,6 @@ public:
   /// \param node Lifecycle node used to create the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. It must be "sensor_msgs/msg/NavSatFix".
-  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the GNSSPerception to be updated.
   /// \param cb_group Callback group for executor-level concurrency control.
   /// \return Shared pointer to the created subscription.
@@ -96,7 +95,6 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
-    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/include/easynav_common/types/GNSSPerception.hpp
+++ b/easynav_common/include/easynav_common/types/GNSSPerception.hpp
@@ -29,11 +29,9 @@
 
 #include <string>
 #include <vector>
-#include <optional>
 
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 
-#include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "easynav_common/types/Perceptions.hpp"

--- a/easynav_common/include/easynav_common/types/GNSSPerception.hpp
+++ b/easynav_common/include/easynav_common/types/GNSSPerception.hpp
@@ -90,6 +90,7 @@ public:
   /// \param node Lifecycle node used to create the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. It must be "sensor_msgs/msg/NavSatFix".
+  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the GNSSPerception to be updated.
   /// \param cb_group Callback group for executor-level concurrency control.
   /// \return Shared pointer to the created subscription.
@@ -97,6 +98,7 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
+    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/include/easynav_common/types/IMUPerception.hpp
+++ b/easynav_common/include/easynav_common/types/IMUPerception.hpp
@@ -29,11 +29,9 @@
 
 #include <string>
 #include <vector>
-#include <optional>
 
 #include "sensor_msgs/msg/imu.hpp"
 
-#include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "easynav_common/types/Perceptions.hpp"

--- a/easynav_common/include/easynav_common/types/IMUPerception.hpp
+++ b/easynav_common/include/easynav_common/types/IMUPerception.hpp
@@ -90,6 +90,7 @@ public:
   /// \param node Lifecycle node used to create the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. It must be "sensor_msgs/msg/Imu".
+  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the IMUPerception to be updated.
   /// \param cb_group Callback group for executor-level concurrency control.
   /// \return Shared pointer to the created subscription.
@@ -97,6 +98,7 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
+    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/include/easynav_common/types/IMUPerception.hpp
+++ b/easynav_common/include/easynav_common/types/IMUPerception.hpp
@@ -88,7 +88,6 @@ public:
   /// \param node Lifecycle node used to create the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. It must be "sensor_msgs/msg/Imu".
-  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the IMUPerception to be updated.
   /// \param cb_group Callback group for executor-level concurrency control.
   /// \return Shared pointer to the created subscription.
@@ -96,7 +95,6 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
-    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/include/easynav_common/types/ImagePerception.hpp
+++ b/easynav_common/include/easynav_common/types/ImagePerception.hpp
@@ -32,9 +32,7 @@
 #include <optional>
 
 #include "cv_bridge/cv_bridge.hpp"
-#include "sensor_msgs/msg/image.hpp"
 
-#include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "easynav_common/types/Perceptions.hpp"

--- a/easynav_common/include/easynav_common/types/ImagePerception.hpp
+++ b/easynav_common/include/easynav_common/types/ImagePerception.hpp
@@ -93,7 +93,6 @@ public:
   /// \param node Lifecycle node used to create the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. It must be "sensor_msgs/msg/Image".
-  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the ImagePerception to be updated.
   /// \param cb_group Callback group for executor-level concurrency control.
   /// \return Shared pointer to the created subscription.
@@ -101,7 +100,6 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
-    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/include/easynav_common/types/ImagePerception.hpp
+++ b/easynav_common/include/easynav_common/types/ImagePerception.hpp
@@ -95,6 +95,7 @@ public:
   /// \param node Lifecycle node used to create the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. It must be "sensor_msgs/msg/Image".
+  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the ImagePerception to be updated.
   /// \param cb_group Callback group for executor-level concurrency control.
   /// \return Shared pointer to the created subscription.
@@ -102,6 +103,7 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
+    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/include/easynav_common/types/Perceptions.hpp
+++ b/easynav_common/include/easynav_common/types/Perceptions.hpp
@@ -31,12 +31,6 @@
 
 #include <string>
 
-#include "sensor_msgs/msg/laser_scan.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
-
-#include "pcl/point_cloud.h"
-#include "pcl/point_types.h"
-
 #include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 

--- a/easynav_common/include/easynav_common/types/Perceptions.hpp
+++ b/easynav_common/include/easynav_common/types/Perceptions.hpp
@@ -135,7 +135,6 @@ public:
   /// \param node Reference to the lifecycle node used for creating the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name (e.g., `"sensor_msgs/msg/LaserScan"`).
-  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer where perception results are stored.
   /// \param cb_group Callback group where the subscription callback will be executed.
   /// \return Shared pointer to the created subscription.
@@ -143,7 +142,6 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
-    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) = 0;
 

--- a/easynav_common/include/easynav_common/types/Perceptions.hpp
+++ b/easynav_common/include/easynav_common/types/Perceptions.hpp
@@ -141,6 +141,7 @@ public:
   /// \param node Reference to the lifecycle node used for creating the subscription.
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name (e.g., `"sensor_msgs/msg/LaserScan"`).
+  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer where perception results are stored.
   /// \param cb_group Callback group where the subscription callback will be executed.
   /// \return Shared pointer to the created subscription.
@@ -148,6 +149,7 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
+    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) = 0;
 

--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -35,9 +35,6 @@
 #include <vector>
 #include <optional>
 
-#include "pcl_conversions/pcl_conversions.h"
-#include "pcl/point_types_conversion.h"
-#include "pcl/common/transforms.h"
 #include "pcl/point_cloud.h"
 #include "pcl/point_types.h"
 #include "pcl/PointIndices.h"

--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -132,7 +132,6 @@ public:
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. Must be either \c "sensor_msgs/msg/LaserScan"
   ///             or \c "sensor_msgs/msg/PointCloud2".
-  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the perception instance to be updated.
   /// \param cb_group Callback group for the subscription callback (executor-level concurrency control).
   /// \return Shared pointer to the created subscription.
@@ -140,7 +139,6 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
-    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -134,6 +134,7 @@ public:
   /// \param topic Topic name to subscribe to.
   /// \param type ROS message type name. Must be either \c "sensor_msgs/msg/LaserScan"
   ///             or \c "sensor_msgs/msg/PointCloud2".
+  /// \param queue_size Size of the subscription queue, passed to the QoS config.
   /// \param target Shared pointer to the perception instance to be updated.
   /// \param cb_group Callback group for the subscription callback (executor-level concurrency control).
   /// \return Shared pointer to the created subscription.
@@ -141,6 +142,7 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     const std::string & type,
+    const int queue_size,
     std::shared_ptr<PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group) override;
 };

--- a/easynav_common/src/easynav_common/types/GNSSPerception.cpp
+++ b/easynav_common/src/easynav_common/types/GNSSPerception.cpp
@@ -38,6 +38,7 @@ GNSSPerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
+  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -49,7 +50,7 @@ GNSSPerceptionHandler::create_subscription(
   options.callback_group = cb_group;
 
   return node.create_subscription<sensor_msgs::msg::NavSatFix>(
-    topic, rclcpp::SensorDataQoS().reliable(),
+    topic, rclcpp::QoS(queue_size),
     [target](const sensor_msgs::msg::NavSatFix::SharedPtr msg)
     {
       auto typed_target = std::dynamic_pointer_cast<GNSSPerception>(target);

--- a/easynav_common/src/easynav_common/types/GNSSPerception.cpp
+++ b/easynav_common/src/easynav_common/types/GNSSPerception.cpp
@@ -36,7 +36,6 @@ GNSSPerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
-  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -48,7 +47,7 @@ GNSSPerceptionHandler::create_subscription(
   options.callback_group = cb_group;
 
   return node.create_subscription<sensor_msgs::msg::NavSatFix>(
-    topic, rclcpp::QoS(queue_size),
+    topic, rclcpp::QoS(1),
     [target](const sensor_msgs::msg::NavSatFix::SharedPtr msg)
     {
       auto typed_target = std::dynamic_pointer_cast<GNSSPerception>(target);

--- a/easynav_common/src/easynav_common/types/GNSSPerception.cpp
+++ b/easynav_common/src/easynav_common/types/GNSSPerception.cpp
@@ -19,8 +19,6 @@
 
 
 #include <string>
-#include <vector>
-#include <optional>
 
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 

--- a/easynav_common/src/easynav_common/types/IMUPerception.cpp
+++ b/easynav_common/src/easynav_common/types/IMUPerception.cpp
@@ -38,6 +38,7 @@ IMUPerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
+  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -49,7 +50,7 @@ IMUPerceptionHandler::create_subscription(
   options.callback_group = cb_group;
 
   return node.create_subscription<sensor_msgs::msg::Imu>(
-    topic, rclcpp::SensorDataQoS().reliable(),
+    topic, rclcpp::QoS(queue_size),
     [target](const sensor_msgs::msg::Imu::SharedPtr msg)
     {
       auto typed_target = std::dynamic_pointer_cast<IMUPerception>(target);

--- a/easynav_common/src/easynav_common/types/IMUPerception.cpp
+++ b/easynav_common/src/easynav_common/types/IMUPerception.cpp
@@ -19,8 +19,6 @@
 
 
 #include <string>
-#include <vector>
-#include <optional>
 
 #include "sensor_msgs/msg/imu.hpp"
 

--- a/easynav_common/src/easynav_common/types/IMUPerception.cpp
+++ b/easynav_common/src/easynav_common/types/IMUPerception.cpp
@@ -36,7 +36,6 @@ IMUPerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
-  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -48,7 +47,7 @@ IMUPerceptionHandler::create_subscription(
   options.callback_group = cb_group;
 
   return node.create_subscription<sensor_msgs::msg::Imu>(
-    topic, rclcpp::QoS(queue_size),
+    topic, rclcpp::QoS(1),
     [target](const sensor_msgs::msg::Imu::SharedPtr msg)
     {
       auto typed_target = std::dynamic_pointer_cast<IMUPerception>(target);

--- a/easynav_common/src/easynav_common/types/ImagePerception.cpp
+++ b/easynav_common/src/easynav_common/types/ImagePerception.cpp
@@ -37,7 +37,6 @@ ImagePerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
-  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -49,7 +48,7 @@ ImagePerceptionHandler::create_subscription(
   options.callback_group = cb_group;
 
   return node.create_subscription<sensor_msgs::msg::Image>(
-    topic, rclcpp::QoS(queue_size),
+    topic, rclcpp::QoS(1),
     [target](const sensor_msgs::msg::Image::SharedPtr msg)
     {
       auto typed_target = std::dynamic_pointer_cast<ImagePerception>(target);

--- a/easynav_common/src/easynav_common/types/ImagePerception.cpp
+++ b/easynav_common/src/easynav_common/types/ImagePerception.cpp
@@ -19,8 +19,6 @@
 
 
 #include <string>
-#include <vector>
-#include <optional>
 
 #include "cv_bridge/cv_bridge.hpp"
 #include "sensor_msgs/msg/image.hpp"

--- a/easynav_common/src/easynav_common/types/ImagePerception.cpp
+++ b/easynav_common/src/easynav_common/types/ImagePerception.cpp
@@ -39,6 +39,7 @@ ImagePerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
+  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -50,7 +51,7 @@ ImagePerceptionHandler::create_subscription(
   options.callback_group = cb_group;
 
   return node.create_subscription<sensor_msgs::msg::Image>(
-    topic, rclcpp::SensorDataQoS().reliable(),
+    topic, rclcpp::QoS(queue_size),
     [target](const sensor_msgs::msg::Image::SharedPtr msg)
     {
       auto typed_target = std::dynamic_pointer_cast<ImagePerception>(target);

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -46,7 +46,6 @@ PointPerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
-  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -55,7 +54,7 @@ PointPerceptionHandler::create_subscription(
 
   if (type == "sensor_msgs/msg/PointCloud2") {
     return node.create_subscription<sensor_msgs::msg::PointCloud2>(
-      topic, rclcpp::QoS(queue_size),
+      topic, rclcpp::QoS(1),
       [target](const sensor_msgs::msg::PointCloud2::SharedPtr msg)
       {
         auto typed_target = std::dynamic_pointer_cast<PointPerception>(target);

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -49,6 +49,7 @@ PointPerceptionHandler::create_subscription(
   rclcpp_lifecycle::LifecycleNode & node,
   const std::string & topic,
   const std::string & type,
+  const int queue_size,
   std::shared_ptr<PerceptionBase> target,
   rclcpp::CallbackGroup::SharedPtr cb_group)
 {
@@ -57,7 +58,7 @@ PointPerceptionHandler::create_subscription(
 
   if (type == "sensor_msgs/msg/PointCloud2") {
     return node.create_subscription<sensor_msgs::msg::PointCloud2>(
-      topic, rclcpp::SensorDataQoS().reliable(),
+      topic, rclcpp::QoS(queue_size),
       [target](const sensor_msgs::msg::PointCloud2::SharedPtr msg)
       {
         auto typed_target = std::dynamic_pointer_cast<PointPerception>(target);

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -22,12 +22,9 @@
 #include <optional>
 
 #include "pcl_conversions/pcl_conversions.h"
-#include "pcl/point_types_conversion.h"
 
-#include "pcl/common/transforms.h"
 #include "pcl/point_cloud.h"
 #include "pcl/point_types.h"
-#include "pcl/PointIndices.h"
 
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 

--- a/easynav_common/tests/perceptions_tests.cpp
+++ b/easynav_common/tests/perceptions_tests.cpp
@@ -272,6 +272,7 @@ TEST_F(PerceptionsTestCase, PointPerceptionHandlerWorks)
     *node,
     "/test_scan",
     "sensor_msgs/msg/LaserScan",
+    5,
     perception,
     cb_group);
 
@@ -322,6 +323,7 @@ TEST_F(PerceptionsTestCase, PointPerceptionHandlerPC2Works)
     *node,
     "/test_pc2",
     "sensor_msgs/msg/PointCloud2",
+    5,
     perception,
     cb_group);
 
@@ -388,6 +390,7 @@ TEST_F(PerceptionsTestCase, ImagePerceptionHandlerWorks)
     *node,
     "/test_image",
     "sensor_msgs/msg/Image",
+    5,
     perception,
     cb_group);
 
@@ -446,7 +449,8 @@ public:
   rclcpp::SubscriptionBase::SharedPtr create_subscription(
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
-    const std::string &,
+    [[maybe_unused]] const std::string & type,
+    const int queue_size,
     std::shared_ptr<easynav::PerceptionBase> target,
     rclcpp::CallbackGroup::SharedPtr cb_group)
   {
@@ -454,7 +458,7 @@ public:
     options.callback_group = cb_group;
 
     return node.create_subscription<std_msgs::msg::String>(
-      topic, rclcpp::QoS(1).reliable(),
+      topic, rclcpp::QoS(queue_size),
       [target](const std_msgs::msg::String::SharedPtr msg)
       {
         auto p = std::dynamic_pointer_cast<DummyPerception>(target);
@@ -478,6 +482,7 @@ TEST_F(PerceptionsTestCase, CustomPerceptionHandlerCanBeRegistered)
     *node,
     "/dummy_topic",
     "std_msgs/msg/String",
+    1,
     perception,
     cb_group);
 

--- a/easynav_common/tests/perceptions_tests.cpp
+++ b/easynav_common/tests/perceptions_tests.cpp
@@ -21,20 +21,14 @@
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "easynav_common/types/Perceptions.hpp"
 #include "easynav_common/types/PointPerception.hpp"
 #include "easynav_common/types/ImagePerception.hpp"
 
-#include "lifecycle_msgs/msg/transition.hpp"
-#include "lifecycle_msgs/msg/state.hpp"
-
 #include "pcl/point_types.h"
 #include "pcl_conversions/pcl_conversions.h"
-#include "pcl/point_types_conversion.h"
-#include "pcl/common/transforms.h"
-#include "tf2_ros/transform_broadcaster.hpp"
-#include "tf2/transform_datatypes.hpp"
 
 #include "gtest/gtest.h"
 
@@ -272,7 +266,6 @@ TEST_F(PerceptionsTestCase, PointPerceptionHandlerWorks)
     *node,
     "/test_scan",
     "sensor_msgs/msg/LaserScan",
-    5,
     perception,
     cb_group);
 
@@ -323,7 +316,6 @@ TEST_F(PerceptionsTestCase, PointPerceptionHandlerPC2Works)
     *node,
     "/test_pc2",
     "sensor_msgs/msg/PointCloud2",
-    5,
     perception,
     cb_group);
 
@@ -390,7 +382,6 @@ TEST_F(PerceptionsTestCase, ImagePerceptionHandlerWorks)
     *node,
     "/test_image",
     "sensor_msgs/msg/Image",
-    5,
     perception,
     cb_group);
 
@@ -450,15 +441,14 @@ public:
     rclcpp_lifecycle::LifecycleNode & node,
     const std::string & topic,
     [[maybe_unused]] const std::string & type,
-    const int queue_size,
     std::shared_ptr<easynav::PerceptionBase> target,
-    rclcpp::CallbackGroup::SharedPtr cb_group)
+    rclcpp::CallbackGroup::SharedPtr cb_group) override
   {
     auto options = rclcpp::SubscriptionOptions();
     options.callback_group = cb_group;
 
     return node.create_subscription<std_msgs::msg::String>(
-      topic, rclcpp::QoS(queue_size),
+      topic, rclcpp::QoS(1),
       [target](const std_msgs::msg::String::SharedPtr msg)
       {
         auto p = std::dynamic_pointer_cast<DummyPerception>(target);
@@ -482,7 +472,6 @@ TEST_F(PerceptionsTestCase, CustomPerceptionHandlerCanBeRegistered)
     *node,
     "/dummy_topic",
     "std_msgs/msg/String",
-    1,
     perception,
     cb_group);
 

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -34,9 +34,7 @@ std::expected<void, std::string> DummyController::on_initialize()
   const auto & plugin_name = get_plugin_name();
 
   node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
-  node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
   node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
-  node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 
   // Initialize the odometry message
   cmd_vel_.header.stamp = get_node()->now();
@@ -53,13 +51,16 @@ std::expected<void, std::string> DummyController::on_initialize()
 
 void DummyController::update_rt([[maybe_unused]] NavState & nav_state)
 {
-  auto start = get_node()->now();
-  while ((get_node()->now() - start).seconds() < cycle_time_rt_) {}
+  namespace chr = std::chrono;
+  auto start = chr::steady_clock::now();
 
   // Compute the current command...
   // cmd_vel_.angular.z = 1.0;
 
   // nav_state.set("cmd_vel", cmd_vel_);
+
+  // Busy wait to simulate processing time
+  while (chr::duration<double>(chr::steady_clock::now() - start).count() < cycle_time_rt_) {}
 }
 
 }  // namespace easynav

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -38,7 +38,11 @@ ControllerMethodBase::internal_update_rt(NavState & nav_state, bool trigger)
   if (isTime2RunRT() || trigger) {
     EASYNAV_TRACE_EVENT;
 
+    // Save last execution time, even if triggered
+    setRunRT();
+
     update_rt(nav_state);
+
     return true;
   } else {
     return false;

--- a/easynav_core/src/easynav_core/LocalizerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/LocalizerMethodBase.cpp
@@ -38,7 +38,11 @@ LocalizerMethodBase::internal_update_rt(NavState & nav_state, bool trigger)
   if (isTime2RunRT() || trigger) {
     EASYNAV_TRACE_EVENT;
 
+    // Save last execution time, even if triggered
+    setRunRT();
+
     update_rt(nav_state);
+
     return true;
   } else {
     return false;
@@ -49,7 +53,10 @@ void
 LocalizerMethodBase::internal_update(NavState & nav_state)
 {
   if (isTime2Run()) {
+
     EASYNAV_TRACE_EVENT;
+    // Save last execution time, even if triggered
+    setRun();
 
     update(nav_state);
   }

--- a/easynav_core/src/easynav_core/MapsManagerBase.cpp
+++ b/easynav_core/src/easynav_core/MapsManagerBase.cpp
@@ -38,6 +38,9 @@ MapsManagerBase::internal_update(NavState & nav_state)
   if (isTime2Run()) {
     EASYNAV_TRACE_EVENT;
 
+    // Save last execution time, even if triggered
+    setRun();
+
     update(nav_state);
   }
 }

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -76,8 +76,9 @@ MethodBase::get_tf_prefix() const
 bool
 MethodBase::isTime2RunRT()
 {
-  if ((parent_node_->now() - rt_last_ts_).seconds() > (1.0 / rt_frequency_)) {
-    rt_last_ts_ = parent_node_->now();
+  const auto now = parent_node_->now();
+  if ((now - rt_last_ts_).seconds() >= (1.0 / rt_frequency_)) {
+    rt_last_ts_ = now;
     return true;
   } else {
     return false;
@@ -87,8 +88,9 @@ MethodBase::isTime2RunRT()
 bool
 MethodBase::isTime2Run()
 {
-  if ((parent_node_->now() - last_ts_).seconds() > (1.0 / frequency_)) {
-    last_ts_ = parent_node_->now();
+  const auto now = parent_node_->now();
+  if ((now - last_ts_).seconds() > (1.0 / frequency_)) {
+    last_ts_ = now;
     return true;
   } else {
     return false;

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -77,7 +77,15 @@ bool
 MethodBase::isTime2RunRT()
 {
   const auto now = parent_node_->now();
-  if ((now - rt_last_ts_).seconds() >= (1.0 / rt_frequency_)) {
+  const double target_cycle_time = 1.0 / rt_frequency_;
+  const double cycle_time = (now - rt_last_ts_).seconds();
+  if (cycle_time >= target_cycle_time) {
+    if (cycle_time > 1.5 * target_cycle_time) {
+      RCLCPP_WARN_THROTTLE(
+          parent_node_->get_logger(), *parent_node_->get_clock(), 2000,
+          "[%s] RT cycle time exceeded target by more than 1.5x (%.3f s > %.3f s)",
+          plugin_name_.c_str(), cycle_time, target_cycle_time);
+    }
     rt_last_ts_ = now;
     return true;
   } else {
@@ -89,7 +97,15 @@ bool
 MethodBase::isTime2Run()
 {
   const auto now = parent_node_->now();
-  if ((now - last_ts_).seconds() > (1.0 / frequency_)) {
+  const double target_cycle_time = 1.0 / frequency_;
+  const double cycle_time = (now - last_ts_).seconds();
+  if (cycle_time >= target_cycle_time) {
+    if (cycle_time > 1.5 * target_cycle_time) {
+      RCLCPP_WARN_THROTTLE(
+        parent_node_->get_logger(), *parent_node_->get_clock(), 2000,
+        "[%s] target cycle time exceeded by more than 1.5x (%.3f s > %.3f s)",
+        plugin_name_.c_str(), cycle_time, target_cycle_time);
+    }
     last_ts_ = now;
     return true;
   } else {

--- a/easynav_core/src/easynav_core/PlannerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/PlannerMethodBase.cpp
@@ -37,6 +37,10 @@ PlannerMethodBase::internal_update(NavState & nav_state)
 {
   if (isTime2Run()) {
     EASYNAV_TRACE_EVENT;
+
+    // Save last execution time, even if triggered
+    setRun();
+
     update(nav_state);
   }
 }

--- a/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
+++ b/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
@@ -45,8 +45,9 @@ std::expected<void, std::string> DummyLocalizer::on_initialize()
 
 void DummyLocalizer::update_rt([[maybe_unused]] NavState & nav_state)
 {
-  auto start = get_node()->now();
-  while ((get_node()->now() - start).seconds() < cycle_time_rt_) {}
+  namespace chr = std::chrono;
+  auto start = chr::steady_clock::now();
+
 
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
@@ -57,13 +58,15 @@ void DummyLocalizer::update_rt([[maybe_unused]] NavState & nav_state)
   // tf_broadcaster_->sendTransform(tf_msg);
 
   nav_state.set("robot_pose", robot_pose_);
+
+  // Busy wait to simulate processing time
+  while (chr::duration<double>(chr::steady_clock::now() - start).count() < cycle_time_rt_) {}
 }
 
 void DummyLocalizer::update([[maybe_unused]] NavState & nav_state)
 {
-  auto start = get_node()->now();
-  while ((get_node()->now() - start).seconds() < cycle_time_nort_) {}
-
+  namespace chr = std::chrono;
+  auto start = chr::steady_clock::now();
 
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
@@ -74,6 +77,9 @@ void DummyLocalizer::update([[maybe_unused]] NavState & nav_state)
   // tf_broadcaster_->sendTransform(tf_msg);
 
   nav_state.set("robot_pose", robot_pose_);
+
+  // Busy wait to simulate processing time
+  while (chr::duration<double>(chr::steady_clock::now() - start).count() < cycle_time_nort_) {}
 }
 
 }  // namespace easynav

--- a/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
@@ -32,9 +32,7 @@ std::expected<void, std::string> DummyMapsManager::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
   node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
-  node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 
   return {};
@@ -43,8 +41,10 @@ std::expected<void, std::string> DummyMapsManager::on_initialize()
 void
 DummyMapsManager::update([[maybe_unused]] NavState & nav_state)
 {
-  auto start = get_node()->now();
-  while ((get_node()->now() - start).seconds() < cycle_time_nort_) {}
+  // Busy wait to simulate processing time
+  namespace chr = std::chrono;
+  auto start = chr::steady_clock::now();
+  while (chr::duration<double>(chr::steady_clock::now() - start).count() < cycle_time_nort_) {}
 }
 
 }  // namespace easynav

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -32,9 +32,7 @@ std::expected<void, std::string> DummyPlanner::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
   node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
-  node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 
   // Initialize the Path message
@@ -47,10 +45,13 @@ std::expected<void, std::string> DummyPlanner::on_initialize()
 
 void DummyPlanner::update([[maybe_unused]] NavState & nav_state)
 {
-  auto start = get_node()->now();
-  while ((get_node()->now() - start).seconds() < cycle_time_nort_) {}
+  namespace chr = std::chrono;
+  auto start = chr::steady_clock::now();
 
   // Compute the current path...
+
+  // Busy wait to simulate processing time
+  while (chr::duration<double>(chr::steady_clock::now() - start).count() < cycle_time_nort_) {}
 }
 
 }  // namespace easynav

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -23,12 +23,11 @@
 #ifndef EASYNAV_SENSORS__SENSORNODE_HPP_
 #define EASYNAV_SENSORS__SENSORNODE_HPP_
 
+#include <unordered_map>
+
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
-
-#include "tf2_ros/buffer.hpp"
-#include "tf2_ros/transform_listener.hpp"
 
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
@@ -49,6 +48,18 @@ class SensorsNode : public rclcpp_lifecycle::LifecycleNode
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(SensorsNode)
   using CallbackReturnT = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+  /**
+   * @brief Function pointer type used to handle sensor groups
+   * @param group Sensor group name.
+   * @param perceptions List of perceptions (one element from each sensor in the group).
+   * @param ns Navigation state to populate.
+   */
+  using SensorsHandlerFn = void(*)(
+    const std::string & group,
+    const std::vector<easynav::PerceptionPtr> & perceptions,
+    ::easynav::NavState & ns
+  );
 
   /**
    * @brief Constructor.
@@ -144,6 +155,29 @@ private:
 
   std::map<std::string, std::vector<PerceptionPtr>> perceptions_;
   std::map<std::string, std::shared_ptr<PerceptionHandler>> handlers_;
+
+  /// @brief Map from group name to handler function pointer (for fast dispatch in set_by_group)
+  std::unordered_map<std::string, SensorsHandlerFn> group_to_handler_;
+
+  /**
+   * @brief Populate NavState for a given group from perceptions; returns true if handled
+   * @param group Sensor group name.
+   * @param perceptoins Vector of perceptions (one element from each sensor in the group).
+   * @param ns Navigation state to populate.
+   */
+  bool set_by_group(
+    const std::string & group,
+    const std::vector<PerceptionPtr> & perceptoins,
+    ::easynav::NavState & ns
+  );
+
+  /**
+   * @brief Populate the runtime map group_to_handler_.
+   * This method uses compile-time template recursion to fill the map
+   * with the sensor handler functions for the default groups.
+   */
+  template<std::size_t I = 0>
+  void populate_group_to_handler_map();
 };
 
 }  // namespace easynav

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -162,12 +162,12 @@ private:
   /**
    * @brief Populate NavState for a given group from perceptions; returns true if handled
    * @param group Sensor group name.
-   * @param perceptoins Vector of perceptions (one element from each sensor in the group).
+   * @param perceptions Vector of perceptions (one element from each sensor in the group).
    * @param ns Navigation state to populate.
    */
   bool set_by_group(
     const std::string & group,
-    const std::vector<PerceptionPtr> & perceptoins,
+    const std::vector<PerceptionPtr> & perceptions,
     ::easynav::NavState & ns
   );
 

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <vector>
 #include <unordered_map>
+#include <array>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/macros.hpp"
@@ -32,11 +33,9 @@
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
-#include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
 #include "easynav_sensors/SensorsNode.hpp"
-#include "easynav_common/YTSession.hpp"
 
 #include "easynav_common/types/ImagePerception.hpp"
 #include "easynav_common/types/PointPerception.hpp"
@@ -46,23 +45,17 @@
 namespace easynav
 {
 
+/// Anonymous namespace for helper functions
+namespace
+{
+
+// Compile-time Perception type registry
 using Registry = std::tuple<
   easynav::ImagePerception,
   easynav::IMUPerception,
   easynav::GNSSPerception,
   easynav::PointPerception
 >;
-
-namespace
-{
-static std::unordered_map<std::string, std::string> g_group_alias;
-}
-
-inline std::string
-resolve_group_from_msg([[maybe_unused]] std::string_view msg_type, std::true_type)
-{
-  return {};
-}
 
 template<std::size_t I = 0>
 std::string resolve_group_from_msg(std::string_view msg_type)
@@ -78,32 +71,62 @@ std::string resolve_group_from_msg(std::string_view msg_type)
   }
 }
 
-template<std::size_t I = 0>
-bool set_by_group(
+/**
+ * Specialized handler function for a given perception type index.
+ * This function is called when processing the perceptions from a sensor group.
+ */
+template<std::size_t I>
+void perception_handler_fn(
+  const std::string & group,
+  const std::vector<easynav::PerceptionPtr> & perceptions,
+  ::easynav::NavState & ns
+)
+{
+  using P = std::tuple_element_t<I, Registry>;
+  ns.set(group, get_perceptions<P>(perceptions));
+}
+
+template<std::size_t... Is>
+constexpr auto make_handler_table(std::index_sequence<Is...>)
+{
+  return std::array<SensorsNode::SensorsHandlerFn, sizeof...(Is)>{&perception_handler_fn<Is>...};
+}
+
+/// Compile-time helper table that maps type indices from the Registry to handler function pointers
+constexpr auto perception_handler_table =
+  make_handler_table(std::make_index_sequence<std::tuple_size_v<Registry>>());
+
+}
+
+// SensorsNode member function to populate the runtime map using compile-time template recursion
+template<std::size_t I>
+void SensorsNode::populate_group_to_handler_map()
+{
+  if constexpr (I < std::tuple_size_v<Registry>) {
+    using P = std::tuple_element_t<I, Registry>;
+    group_to_handler_.emplace(std::string(P::default_group_), perception_handler_table[I]);
+    populate_group_to_handler_map<I + 1>();
+  }
+}
+
+bool
+SensorsNode::set_by_group(
   const std::string & group,
   const std::vector<easynav::PerceptionPtr> & src,
   ::easynav::NavState & ns)
 {
-  if constexpr (I >= std::tuple_size_v<Registry>) {
+  // Find the perception handler function to process this group
+  auto it = group_to_handler_.find(group);
+  if (it == group_to_handler_.end()) {
+    // If there is no handler registered for this group, return false
     return false;
-  } else {
-    using P = std::tuple_element_t<I, Registry>;
-
-    const bool match_direct = (group == P::default_group_);
-    const bool match_alias =
-      (!match_direct) &&
-      (g_group_alias.find(group) != g_group_alias.end()) &&
-      (g_group_alias[group] == P::default_group_);
-
-    if (match_direct || match_alias) {
-      ns.set(group, get_perceptions<P>(src));
-      return true;
-    }
-    return set_by_group<I + 1>(group, src, ns);
   }
+
+  // Call the handler function pointer stored for this group
+  it->second(group, src, ns);
+  return true;
 }
 
-using namespace std::chrono_literals;
 
 SensorsNode::SensorsNode(const rclcpp::NodeOptions & options)
 : LifecycleNode("sensors_node", options)
@@ -186,6 +209,8 @@ SensorsNode::SensorsNode(const rclcpp::NodeOptions & options)
   register_handler(std::make_shared<ImagePerceptionHandler>());
   register_handler(std::make_shared<IMUPerceptionHandler>());
   register_handler(std::make_shared<GNSSPerceptionHandler>());
+  // Populate map from default group strings to handler function pointers for fast dispatch
+  populate_group_to_handler_map();
 }
 
 SensorsNode::~SensorsNode()
@@ -198,12 +223,8 @@ SensorsNode::~SensorsNode()
 
 using CallbackReturnT = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 CallbackReturnT
-SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
+SensorsNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
-  g_group_alias.clear();
-
   std::vector<std::string> sensors;
   get_parameter("sensors", sensors);
   get_parameter("forget_time", forget_time_);
@@ -229,27 +250,31 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
     get_parameter(sensor_id + ".type", msg_type);
     get_parameter(sensor_id + ".queue_size", queue_size);
 
-    group = resolve_group_from_msg(msg_type);
+    // Resolve canonical group from message type
+    const std::string canonical_group = resolve_group_from_msg(msg_type);
 
     if (!has_parameter(sensor_id + ".group")) {
-      declare_parameter(sensor_id + ".group", group);
+      declare_parameter(sensor_id + ".group", canonical_group);
     }
 
     get_parameter(sensor_id + ".group", group);
 
+    // Find handler for the requested group (may be custom/aliased)
     auto handler_it = handlers_.find(group);
-    if (handler_it == handlers_.end()) {
-      const std::string canonical = resolve_group_from_msg(msg_type);
-      if (!canonical.empty()) {
-        auto hit2 = handlers_.find(canonical);
-        if (hit2 != handlers_.end()) {
-          handlers_[group] = hit2->second;
-          g_group_alias[group] = canonical;
-          handler_it = handlers_.find(group);
-          RCLCPP_INFO(get_logger(),
-                      "Aliased group '%s' -> '%s' for type '%s'",
-                      group.c_str(), canonical.c_str(), msg_type.c_str());
+    if (handler_it == handlers_.end() && !canonical_group.empty()) {
+      // No handler for custom group; try aliasing to canonical group
+      const auto canonical_handler_it = handlers_.find(canonical_group);
+      if (canonical_handler_it != handlers_.end()) {
+        // Use handler from canonical group
+        handlers_[group] = canonical_handler_it->second;
+        const auto canonical_fn_it = group_to_handler_.find(canonical_group);
+        if (canonical_fn_it != group_to_handler_.end()) {
+          group_to_handler_[group] = canonical_fn_it->second;
         }
+        handler_it = canonical_handler_it;
+        RCLCPP_INFO(get_logger(),
+                    "Aliased group '%s' -> '%s' for type '%s'",
+                    group.c_str(), canonical_group.c_str(), msg_type.c_str());
       }
     }
 
@@ -258,8 +283,8 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
       continue;
     }
 
-    auto perception_ptr = handler_it->second->create(sensor_id);
-    auto sub = handler_it->second->create_subscription(
+    const auto perception_ptr = handler_it->second->create(sensor_id);
+    const auto sub = handler_it->second->create_subscription(
       *this, topic, msg_type, queue_size,
       perception_ptr, realtime_cbg_
     );

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -112,7 +112,7 @@ void SensorsNode::populate_group_to_handler_map()
 bool
 SensorsNode::set_by_group(
   const std::string & group,
-  const std::vector<easynav::PerceptionPtr> & src,
+  const std::vector<easynav::PerceptionPtr> & perceptions,
   ::easynav::NavState & ns)
 {
   // Find the perception handler function to process this group
@@ -123,7 +123,7 @@ SensorsNode::set_by_group(
   }
 
   // Call the handler function pointer stored for this group
-  it->second(group, src, ns);
+  it->second(group, perceptions, ns);
   return true;
 }
 

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -234,7 +234,6 @@ SensorsNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state
 
   for (const auto & sensor_id : sensors) {
     std::string topic, msg_type, group;
-    int queue_size = 1;
 
     if (!has_parameter(sensor_id + ".topic")) {
       declare_parameter(sensor_id + ".topic", topic);
@@ -242,13 +241,9 @@ SensorsNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state
     if (!has_parameter(sensor_id + ".type")) {
       declare_parameter(sensor_id + ".type", msg_type);
     }
-    if (!has_parameter(sensor_id + ".queue_size")) {
-      declare_parameter(sensor_id + ".queue_size", queue_size);
-    }
 
     get_parameter(sensor_id + ".topic", topic);
     get_parameter(sensor_id + ".type", msg_type);
-    get_parameter(sensor_id + ".queue_size", queue_size);
 
     // Resolve canonical group from message type
     const std::string canonical_group = resolve_group_from_msg(msg_type);
@@ -285,8 +280,7 @@ SensorsNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state
 
     const auto perception_ptr = handler_it->second->create(sensor_id);
     const auto sub = handler_it->second->create_subscription(
-      *this, topic, msg_type, queue_size,
-      perception_ptr, realtime_cbg_
+      *this, topic, msg_type, perception_ptr, realtime_cbg_
     );
 
     perceptions_[group].emplace_back(PerceptionPtr{perception_ptr, sub});

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -213,6 +213,7 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
 
   for (const auto & sensor_id : sensors) {
     std::string topic, msg_type, group;
+    int queue_size = 1;
 
     if (!has_parameter(sensor_id + ".topic")) {
       declare_parameter(sensor_id + ".topic", topic);
@@ -220,9 +221,13 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
     if (!has_parameter(sensor_id + ".type")) {
       declare_parameter(sensor_id + ".type", msg_type);
     }
+    if (!has_parameter(sensor_id + ".queue_size")) {
+      declare_parameter(sensor_id + ".queue_size", queue_size);
+    }
 
     get_parameter(sensor_id + ".topic", topic);
     get_parameter(sensor_id + ".type", msg_type);
+    get_parameter(sensor_id + ".queue_size", queue_size);
 
     group = resolve_group_from_msg(msg_type);
 
@@ -253,11 +258,13 @@ SensorsNode::on_configure(const rclcpp_lifecycle::State & state)
       continue;
     }
 
-    auto ptr = handler_it->second->create(sensor_id);
-    auto sub = handler_it->second->create_subscription(*this, topic, msg_type, ptr,
-      realtime_cbg_);
+    auto perception_ptr = handler_it->second->create(sensor_id);
+    auto sub = handler_it->second->create_subscription(
+      *this, topic, msg_type, queue_size,
+      perception_ptr, realtime_cbg_
+    );
 
-    perceptions_[group].emplace_back(PerceptionPtr{ptr, sub});
+    perceptions_[group].emplace_back(PerceptionPtr{perception_ptr, sub});
   }
 
   return CallbackReturnT::SUCCESS;

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -27,6 +27,7 @@
 
 #include "easynav_system/SystemNode.hpp"
 #include "easynav_common/RTTFBuffer.hpp"
+#include <easynav_common/YTSession.hpp>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -86,6 +87,23 @@ int main(int argc, char ** argv)
     system_node->declare_parameter("use_real_time", use_real_time);
     system_node->get_parameter("use_real_time", use_real_time);
 
+    // Get spin duration timeout for both threads
+    double spin_time_rt = 0.001;
+    system_node->declare_parameter("spin_time_rt", spin_time_rt);
+    system_node->get_parameter("spin_time_rt", spin_time_rt);
+    double spin_time_nort = 0.001;
+    system_node->declare_parameter("spin_time_nort", spin_time_nort);
+    system_node->get_parameter("spin_time_nort", spin_time_nort);
+
+    // Convert spin timeouts from seconds to nanoseconds and cast to chrono type
+    const auto spin_duration_rt = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::duration<double>(spin_time_rt)
+    );
+
+    const auto spin_duration_nort = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::duration<double>(spin_time_nort)
+    );
+
     // Cooperative shutdown on SIGINT
     rclcpp::on_shutdown([&](){
         stop.store(true, std::memory_order_relaxed);
@@ -109,20 +127,23 @@ int main(int argc, char ** argv)
 
         tf2_ros::TransformListener tf_listener(*tf_buffer, *tf_node, true);
 
-        rclcpp::WallRate rate(100);
+        rclcpp::WallRate rate(200);
         while (!stop.load(std::memory_order_relaxed)) {
           if (system_node->get_current_state().id() ==
           lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
           {
             system_node->system_cycle_rt();
           }
-          exe_rt.spin_some(std::chrono::milliseconds(1));
+          {
+            EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_rt");
+            exe_rt.spin_all(spin_duration_rt);
+          }
           rate.sleep();
         }
       });
 
     // Non-RT loop
-    rclcpp::WallRate rate(100);
+    rclcpp::WallRate rate(200);
     while (!stop.load(std::memory_order_relaxed)) {
 
       if (system_node->get_current_state().id() ==
@@ -130,8 +151,10 @@ int main(int argc, char ** argv)
       {
         system_node->system_cycle();
       }
-
-      exe_nort.spin_some(std::chrono::milliseconds(1));
+      {
+        EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_nort");
+        exe_nort.spin_all(spin_duration_nort);
+      }
       rate.sleep();
     }
 

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -31,6 +31,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "tf2_ros/transform_listener.hpp"
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
Dear all,

I'm opening this as a draft to show/discuss the changes and I will continue working on this next Monday.

Right now, the main execution cycle (for both RT and no-RT) is something like this:

```system_node::cycle --> spin_some(1ms)```

The current state can generate delays (and even starvation) when processing the callback queues, because the spin timeout may not be enough to process all messages, and we do not get to decide what gets executed. Increasing this time prevents starvation, but each call to `spin_some` [will only process one message from each queue maximum](https://docs.ros.org/en/rolling/p/rclcpp/generated/classrclcpp_1_1Executor.html#_CPPv4N6rclcpp8Executor9spin_someENSt6chrono11nanosecondsE).

In addition to this, right now all sensors are integrated into the system with a subscription configured with `SensorDataQoS()`, which has a default queue size of 5. If the system is not able to process stuff fast enough, it will be getting old data. Moreover, even if we have a queue size of 5 messages, the `SensorsNode` will just get the last message and place it in the `NavState`. Thus, having a queue of size 5 is pointless, because all the modules in the system will only have access to the last message grabbed by the `SensorsNode`.

In this PR I propose the following changes:

1. Change the `spin_some` to `spin_all` with a maximum spin time set by a parameter. This way we allow the system to clear the callback queues, and the user can define how much time it allows the callback processing to "delay" the main execution thread.
2. Increase the wall rate so modules and sensors with higher frequency do not get delayed. Right now it is set at 100Hz, but we could increase it to 200-500Hz. For example, if a controller is set to run at 50Hz, the elapsed time between executions may be sometimes 20ms (correct) and other times 30ms (+50% delay).
3. Allow receiving multiple messages before processing them. Add a `queue_size` parameter to each perception/sensor. This will not only be for the QoS, but also for storage, i.e. if the system receives 5 IMU messages and the queue is big enough, it will store all of them and put them in the `NavState`. I still have to tie up some loose ends regarding the implementation, but I plan to put the messages in a circular buffer and make the `SensorsNode` responsible for handling the buffer and the `new_data` flags for each message.
4. [Maybe - To be discussed] Add a parameter to the sensors to determine if a new message should re-trigger the whole pipeline. Maybe if a new laser scan arrives you want to update localization / control right away. Maybe if you have an IMU at 100Hz you don't want to be bothered by every message.
5. Add warning messages in the system for when a plugin is not run at its desired frequency. This will help users to identify if something is going wrong.

I believe the key things are changing the spin method and adjusting the callback queues, but I am open to any change you consider.

This is a checklist to track the PR progress:

- [x] Change spin method.
- [x] Add spin timeout parameter.
- [x] Increase wall rate.
- [x] Fix bug in dummy methods when computing simulated processing time.
- [x] Add warning messages when missing deadlines.
- [ ] [Optional] Add parameter to enable trigger by new sensor data.
