### PR TITLE
Separate periodic CI from push/PR

### DIFF
--- a/.github/workflows/humble.yaml
+++ b/.github/workflows/humble.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - humble
-  schedule:
-      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -29,7 +27,6 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: humble
-          ref: humble
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/humble_cron.yaml
+++ b/.github/workflows/humble_cron.yaml
@@ -1,32 +1,29 @@
-name: kilted
+name: humble
 
 on:
-  pull_request:
-    branches:
-      - kilted
-  push:
-    branches:
-      - kilted
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-22.04]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: kilted
+          ref: humble
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
         with:
-          required-ros-distributions: kilted
+          required-ros-distributions: humble
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
-          target-ros2-distro: kilted
+          target-ros2-distro: humble
+          ref: humble
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/jazzy.yaml
+++ b/.github/workflows/jazzy.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - jazzy
-  schedule:
-      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -29,7 +27,6 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: jazzy
-          ref: jazzy
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/jazzy_cron.yaml
+++ b/.github/workflows/jazzy_cron.yaml
@@ -1,12 +1,8 @@
-name: kilted
+name: jazzy
 
 on:
-  pull_request:
-    branches:
-      - kilted
-  push:
-    branches:
-      - kilted
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -17,16 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: kilted
+          ref: jazzy
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
         with:
-          required-ros-distributions: kilted
+          required-ros-distributions: jazzy
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
-          target-ros2-distro: kilted
+          target-ros2-distro: jazzy
+          ref: jazzy
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/kilted_cron.yaml
+++ b/.github/workflows/kilted_cron.yaml
@@ -1,12 +1,8 @@
 name: kilted
 
 on:
-  pull_request:
-    branches:
-      - kilted
-  push:
-    branches:
-      - kilted
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -27,6 +23,7 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: kilted
+          ref: kilted
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - rolling
-  schedule:
-      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -29,7 +27,6 @@ jobs:
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
           target-ros2-distro: rolling
-          ref: rolling
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {

--- a/.github/workflows/rolling_cron.yaml
+++ b/.github/workflows/rolling_cron.yaml
@@ -1,12 +1,8 @@
-name: kilted
+name: rolling
 
 on:
-  pull_request:
-    branches:
-      - kilted
-  push:
-    branches:
-      - kilted
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -17,16 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: kilted
+          ref: rolling
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
         with:
-          required-ros-distributions: kilted
+          required-ros-distributions: rolling
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: easynav_common easynav_controller easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_system easynav_support_py easynav_tools
-          target-ros2-distro: kilted
+          target-ros2-distro: rolling
+          ref: rolling
           vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {


### PR DESCRIPTION
Related to the discussion at https://github.com/EasyNavigation/easynav_plugins/pull/26

> @Butakus I found that the last PRs are failing because of #23 . If `ref: <branch>` fixes periodic CI, it makes fail the PR, that's why the last PRs are failing.
> 
> In this PR I fix the CI by creating 2 CI files per branch: one for PR/commits, without `ref: ` and other for periodic job with `ref:`
