### PR TITLE
Collision checker controller

### DIFF
--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -272,6 +272,19 @@ PointPerceptionsOpsView::as_points() const
 {
   pcl::PointCloud<pcl::PointXYZ> output;
 
+  // Estimate total number of points to reserve memory once
+  std::size_t total_points = 0;
+  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
+    auto perception = perceptions_[i];
+
+    if (!perception || !perception->valid || perception->data.empty()) {continue;}
+
+    const auto & index_list = indices_[i].indices;
+    total_points += index_list.size();
+  }
+
+  output.points.reserve(total_points);
+
   for (std::size_t i = 0; i < perceptions_.size(); ++i) {
     auto perception = perceptions_[i];
 
@@ -286,6 +299,10 @@ PointPerceptionsOpsView::as_points() const
       }
     }
   }
+
+  output.width = static_cast<uint32_t>(output.points.size());
+  output.height = 1;
+  output.is_dense = false;
 
   return output;
 }

--- a/easynav_core/CMakeLists.txt
+++ b/easynav_core/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common io)
 
 add_library(${PROJECT_NAME} SHARED
   src/easynav_core/ControllerMethodBase.cpp
@@ -26,6 +27,7 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  ${PCL_INCLUDE_DIRS}
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
   easynav_common::easynav_common
@@ -33,6 +35,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   tf2_ros::tf2_ros
   tf2_geometry_msgs::tf2_geometry_msgs
   ${visualization_msgs_TARGETS}
+  ${PCL_LIBRARIES}
 )
 
 install(
@@ -68,5 +71,6 @@ ament_export_dependencies(
   rclcpp_lifecycle
   visualization_msgs
   tf2_ros
+  PCL
 )
 ament_package()

--- a/easynav_core/CMakeLists.txt
+++ b/easynav_core/CMakeLists.txt
@@ -12,6 +12,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(ament_cmake REQUIRED)
 find_package(easynav_common REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/easynav_core/ControllerMethodBase.cpp
@@ -27,6 +30,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME} PUBLIC
   easynav_common::easynav_common
   rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+  tf2_geometry_msgs::tf2_geometry_msgs
+  ${visualization_msgs_TARGETS}
 )
 
 install(
@@ -60,5 +66,7 @@ ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   easynav_common
   rclcpp_lifecycle
+  visualization_msgs
+  tf2_ros
 )
 ament_package()

--- a/easynav_core/include/easynav_core/ControllerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/ControllerMethodBase.hpp
@@ -51,6 +51,17 @@ public:
   /// @brief Virtual destructor.
   virtual ~ControllerMethodBase() = default;
 
+  /**
+   * @brief Initialize the controller method.
+   *
+   * Creates required publishers, reads configuration parameters and forwards
+   * initialization to MethodBase.
+   *
+   * @param parent_node Reference to the parent lifecycle node.
+   * @param plugin_name Plugin identifier used for namespacing parameters.
+   * @param tf_prefix Optional TF prefix for frame resolution.
+   * @return An empty value on success, or an error message otherwise.
+   */
   virtual std::expected<void, std::string>
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
@@ -78,33 +89,74 @@ protected:
    */
   virtual void update_rt([[maybe_unused]] NavState & nav_state) {}
 
+  /// @brief Enable or disable visualization markers for debugging.
+  bool debug_markers_{false};
 
-  double robot_radius_{0.3};
+  /// @brief Enable or disable collision checking.
+  bool collision_checker_active_{true};
+
+  /// @brief Robot radius used for safety calculations (m).
+  double robot_radius_{0.35};
+
+  /// @brief Vertical extent of the robot used for filtering (m).
   double robot_height_{0.5};
 
-  double brake_acc_{1.0};                   // m/s^2
-  double safety_margin_{0.1};               // m
-  double linear_speed_min_threshold_{0.05};  // m/s
-  double angular_speed_min_threshold_{0.2};  // rad/s
+  /// @brief Minimum Z considered when filtering point clouds (m).
+  double z_min_filter_{0.0};
 
-  double angular_brake_acc_{1.0};           // rad/s^2 (si lo quieres usar)
-  double z_min_filter_{0.0};                // m
-  double rot_safety_margin_{0.05};          // m
+  /// @brief Maximum braking deceleration (m/s²).
+  double brake_acc_{0.5};
 
+  /// @brief Safety margin added to the braking distance (m).
+  double safety_margin_{0.1};
+
+  /// @brief Leaf size used to downsample point clouds (m).
   double downsample_leaf_size_{0.1};
+
+  /// @brief Frame in which motion and collision checks are evaluated.
   std::string motion_frame_{"base_footprint"};
 
+  /// @brief Publisher for collision visualization markers.
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr collision_marker_pub_;
 
+  /**
+   * @brief Detect whether an imminent collision is present.
+   *
+   * The check uses the robot velocity, braking distance, safety margins
+   * and a filtered point cloud in the motion frame. It returns true if any
+   * point lies within the collision prediction region.
+   *
+   * @param nav_state Current navigation state containing velocity and perceptions.
+   * @return True if a collision is predicted, false otherwise.
+   */
   bool is_inminent_collision(NavState & nav_state);
+
+  /**
+   * @brief Callback executed when a collision is detected.
+   *
+   * The default implementation stops the robot by setting a zero Twist.
+   *
+   * @param nav_state Reference to the navigation state to modify.
+   */
   virtual void on_inminent_collision(NavState & nav_state);
 
+  /**
+   * @brief Publish visualization markers for the collision checking region.
+   *
+   * Publishes a CUBE representing the bounding box [min, max] used for
+   * point cloud filtering, and a SPHERE_LIST containing the filtered points
+   * used during the collision evaluation.
+   *
+   * @param min Lower bound of the collision check region [x, y, z].
+   * @param max Upper bound of the collision check region [x, y, z].
+   * @param cloud Filtered point cloud used during collision evaluation.
+   * @param imminent_collision Whether the region is currently considered in collision.
+   */
   void publish_collision_zone_marker(
     const std::vector<double> & min,
     const std::vector<double> & max,
     const pcl::PointCloud<pcl::PointXYZ> & cloud,
     bool imminent_collision);
-
 };
 
 }  // namespace easynav

--- a/easynav_core/include/easynav_core/ControllerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/ControllerMethodBase.hpp
@@ -24,6 +24,7 @@
 #define EASYNAV_CORE__CONTROLLERMETHODBASE_HPP_
 
 #include "geometry_msgs/msg/twist_stamped.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_core/MethodBase.hpp"
@@ -47,6 +48,12 @@ public:
   /// @brief Virtual destructor.
   virtual ~ControllerMethodBase() = default;
 
+  virtual std::expected<void, std::string>
+  initialize(
+    const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
+    const std::string & plugin_name,
+    const std::string & tf_prefix = "");
+
   /**
    * @brief Helper to run the real-time control method if appropriate.
    *
@@ -67,6 +74,34 @@ protected:
    * @param nav_state The current state of the navigation system.
    */
   virtual void update_rt([[maybe_unused]] NavState & nav_state) {}
+
+
+  double robot_radius_{0.3};
+  double robot_height_{0.3};
+
+  double brake_acc_{1.0};                   // m/s^2
+  double safety_margin_{0.1};               // m
+  double linear_speed_min_threshold_{0.05};  // m/s
+  double angular_speed_min_threshold_{0.2};  // rad/s
+
+  double angular_brake_acc_{1.0};           // rad/s^2 (si lo quieres usar)
+  double z_min_filter_{0.0};                // m
+  double rot_safety_margin_{0.05};          // m
+
+  double downsample_leaf_size_{0.1};
+  std::string motion_frame_{"base_link"};
+
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr collision_marker_pub_;
+
+  bool is_inminent_collision(NavState & nav_state);
+  virtual void on_inminent_collision(NavState & nav_state);
+
+void publish_collision_zone_marker(
+  const geometry_msgs::msg::Pose & base_pose,
+  double vx, double vy, double wz,
+  double d_stop,
+  bool imminent_collision);
+
 };
 
 }  // namespace easynav

--- a/easynav_core/include/easynav_core/ControllerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/ControllerMethodBase.hpp
@@ -26,6 +26,9 @@
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
+#include "pcl/point_cloud.h"
+#include "pcl/point_types.h"
+
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_core/MethodBase.hpp"
 
@@ -77,7 +80,7 @@ protected:
 
 
   double robot_radius_{0.3};
-  double robot_height_{0.3};
+  double robot_height_{0.5};
 
   double brake_acc_{1.0};                   // m/s^2
   double safety_margin_{0.1};               // m
@@ -89,18 +92,18 @@ protected:
   double rot_safety_margin_{0.05};          // m
 
   double downsample_leaf_size_{0.1};
-  std::string motion_frame_{"base_link"};
+  std::string motion_frame_{"base_footprint"};
 
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr collision_marker_pub_;
 
   bool is_inminent_collision(NavState & nav_state);
   virtual void on_inminent_collision(NavState & nav_state);
 
-void publish_collision_zone_marker(
-  const geometry_msgs::msg::Pose & base_pose,
-  double vx, double vy, double wz,
-  double d_stop,
-  bool imminent_collision);
+  void publish_collision_zone_marker(
+    const std::vector<double> & min,
+    const std::vector<double> & max,
+    const pcl::PointCloud<pcl::PointXYZ> & cloud,
+    bool imminent_collision);
 
 };
 

--- a/easynav_core/package.xml
+++ b/easynav_core/package.xml
@@ -22,6 +22,7 @@
   <depend>easynav_common</depend>
   <depend>visualization_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>pcl_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/easynav_core/package.xml
+++ b/easynav_core/package.xml
@@ -20,6 +20,9 @@
 
   <depend>rclcpp_lifecycle</depend>
   <depend>easynav_common</depend>
+  <depend>visualization_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -42,7 +42,11 @@ ControllerMethodBase::initialize(
   const std::string & plugin_name,
   const std::string & tf_prefix)
 {
-  parent_node->create_publisher<visualization_msgs::msg::MarkerArray>("collision_area", 10);
+  collision_marker_pub_ = parent_node->create_publisher<visualization_msgs::msg::MarkerArray>(
+    "collision_area", 10);
+
+
+
 
   return MethodBase::initialize(parent_node, plugin_name, tf_prefix);
 }
@@ -65,7 +69,6 @@ ControllerMethodBase::internal_update_rt(NavState & nav_state, bool trigger)
   }
 }
 
-
 void
 ControllerMethodBase::on_inminent_collision(NavState & nav_state)
 {
@@ -76,11 +79,13 @@ ControllerMethodBase::on_inminent_collision(NavState & nav_state)
   nav_state.set("cmd_vel", geometry_msgs::msg::TwistStamped());
 }
 
-
 bool
 ControllerMethodBase::is_inminent_collision(NavState & nav_state)
 {
   std::cerr << "[COLLISION] ========================================" << std::endl;
+
+  bool imminent = false;
+
   if (!nav_state.has("cmd_vel")) {
     std::cerr << "[COLLISION] No cmd_vel in NavState\n";
     return false;
@@ -110,7 +115,6 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
     return false;
   }
 
-
   const double a_brake = std::max(brake_acc_, 1e-3);
   const double d_stop = (v_norm * v_norm) / (2.0 * a_brake) + safety_margin_;
 
@@ -124,7 +128,7 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
     static_cast<double>(-robot_radius_ - safety_margin_),
     static_cast<double>(-robot_radius_ - safety_margin_),
     static_cast<double>(z_min_filter_)});
-   std::vector<double> max({
+  std::vector<double> max({
     static_cast<double>(robot_radius_ + safety_margin_ +
       std::max(0.0, v_norm * v_norm / (2.0 * std::max(brake_acc_, 1e-3)))),
     static_cast<double>(robot_radius_ + safety_margin_),
@@ -135,7 +139,7 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
 
   const auto & cloud = PointPerceptionsOpsView(perceptions)
     .downsample(downsample_leaf_size_)
-    .filter({-2.0, -2.0, -1.0}, {2.0, 2.0, 3.0})
+    .filter({-2.0, -2.0, z_min_filter_}, {2.0, 2.0, robot_height_})
     .fuse(motion_frame_)
     ->filter(min, max)
     .as_points();
@@ -143,50 +147,13 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
   std::cerr << "[COLLISION] Cloud size after fuse/filter: "
             << cloud.size() << "\n";
 
-  if (cloud.empty()) {return false;}
-
-  //
-  // Rotational branch
-  //
-  if (v_norm < linear_speed_min_threshold_ &&
-      std::fabs(wz) > angular_speed_min_threshold_) {
-
-    std::cerr << "[COLLISION] Entering rotation check: v_norm=" << v_norm
-              << " wz=" << wz << "\n";
-
-    const double r_max_rot = robot_radius_ + rot_safety_margin_;
-    const double r_max_rot_sq = r_max_rot * r_max_rot;
-
-    for (const auto & p : cloud.points) {
-      if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
-        std::cerr << "[COLLISION] Skipping invalid point (NaN/Inf) in ROT: ("
-                  << p.x << "," << p.y << "," << p.z << ")\n";
-        continue;
-      }
-
-      if (p.z < z_min_filter_ || p.z > robot_height_) {continue;}
-
-      const double r_sq = static_cast<double>(p.x) * p.x +
-                          static_cast<double>(p.y) * p.y;
-
-      if (r_sq <= r_max_rot_sq) {
-        std::cerr << "[COLLISION] ROT hit at point (" << p.x << ", " << p.y << ", " << p.z
-                  << ") r_sq=" << r_sq << " <= " << r_max_rot_sq << "\n";
-        return true;
-      }
-    }
-
-    std::cerr << "[COLLISION] Rotation: no collision.\n";
+  if (cloud.empty()) {
+    publish_collision_zone_marker(min, max, cloud, imminent);
     return false;
   }
 
-  //
-  // Translational branch
-  //
-  if (v_norm < linear_speed_min_threshold_) {
-    std::cerr << "[COLLISION] v_norm below threshold → no collision\n";
-    return false;
-  }
+  geometry_msgs::msg::Pose base_pose;
+  base_pose.orientation.w = 1.0;
 
   const double r = robot_radius_;
   const double dx = vx / v_norm;
@@ -196,6 +163,7 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
 
   std::cerr << "[COLLISION] Entering translation check dx=" << dx
             << " dy=" << dy
+            << " r_sq=" << r_sq
             << " x_max=" << x_max << "\n";
 
   for (const auto & p : cloud.points) {
@@ -204,13 +172,19 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
                 << p.x << "," << p.y << "," << p.z << ")\n";
       continue;
     }
-    if (p.z < z_min_filter_ || p.z > robot_height_) {continue;}
 
     const double px = p.x;
     const double py = p.y;
 
     const double x_prime =  dx * px + dy * py;
     const double y_prime = -dy * px + dx * py;
+
+
+   std::cerr << "[COLLISION] Point: ("
+                << p.x << "," << p.y << "," << p.z << ")\t"
+                << "x_prime = " << x_prime << "\t"
+                << "y_prime = " << y_prime << "\t"
+                << std::endl;
 
     if (x_prime <= 0.0 || x_prime > x_max) {continue;}
     if ((y_prime * y_prime) > r_sq) {continue;}
@@ -220,18 +194,23 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
               << ") x'=" << x_prime
               << " y'=" << y_prime
               << "\n";
-    return true;
+
+    imminent = true;
+    publish_collision_zone_marker(min, max, cloud, imminent);
+    return imminent;
   }
 
   std::cerr << "[COLLISION] Translation: no collision\n";
-  return false;
+  publish_collision_zone_marker(min, max, cloud, imminent);
+  return imminent;
 }
+
 
 void
 ControllerMethodBase::publish_collision_zone_marker(
-  const geometry_msgs::msg::Pose & base_pose,
-  double vx, double vy, double wz,
-  double d_stop,
+  const std::vector<double> & min,
+  const std::vector<double> & max,
+  const pcl::PointCloud<pcl::PointXYZ> & cloud,
   bool imminent_collision)
 {
   if (!collision_marker_pub_) {
@@ -240,7 +219,7 @@ ControllerMethodBase::publish_collision_zone_marker(
 
   visualization_msgs::msg::MarkerArray array;
 
-  // Borramos todo lo anterior de este namespace
+  // 0) Borrar todo lo anterior en este namespace
   {
     visualization_msgs::msg::Marker clear;
     clear.header.frame_id = motion_frame_;
@@ -253,127 +232,85 @@ ControllerMethodBase::publish_collision_zone_marker(
 
   const rclcpp::Time stamp = get_node()->now();
 
-  // Color según si hay colisión inminente
+  // Color según colisión inminente
   std_msgs::msg::ColorRGBA color;
   color.r = imminent_collision ? 1.0f : 0.0f;
   color.g = imminent_collision ? 0.0f : 1.0f;
   color.b = 0.0f;
-  color.a = 0.25f;  // semitransparente
+  color.a = 0.25f;
 
-  const double v_norm = std::sqrt(vx * vx + vy * vy);
+  // 1) CUBO que representa la caja [min, max] usada en el filtro
+  {
+    visualization_msgs::msg::Marker box;
+    box.header.frame_id = motion_frame_;
+    box.header.stamp = stamp;
+    box.ns = "collision_zone";
+    box.id = 1;
+    box.type = visualization_msgs::msg::Marker::CUBE;
+    box.action = visualization_msgs::msg::Marker::ADD;
 
-  // Altura exacta del volumen que usa is_inminent_collision
-  const double z_min = z_min_filter_;
-  const double z_max = robot_height_;
-  const double z_center = 0.5 * (z_min + z_max);
-  const double z_height = z_max - z_min;
+    // Centro y tamaño del cubo
+    const double cx = 0.5 * (min[0] + max[0]);
+    const double cy = 0.5 * (min[1] + max[1]);
+    const double cz = 0.5 * (min[2] + max[2]);
 
-  // ------------------------------------------------------------------
-  // 1) Volumen de ROTACIÓN: disco/cilindro alrededor del robot
-  // ------------------------------------------------------------------
-  if (v_norm < linear_speed_min_threshold_ &&
-      std::fabs(wz) > angular_speed_min_threshold_) {
+    const double sx = (max[0] - min[0]);
+    const double sy = (max[1] - min[1]);
+    const double sz = (max[2] - min[2]);
 
-    const double r_max_rot = robot_radius_ + rot_safety_margin_;
+    box.pose.position.x = cx;
+    box.pose.position.y = cy;
+    box.pose.position.z = cz;
+    box.pose.orientation.w = 1.0;
 
-    visualization_msgs::msg::Marker m_rot;
-    m_rot.header.frame_id = motion_frame_;
-    m_rot.header.stamp = stamp;
-    m_rot.ns = "collision_zone";
-    m_rot.id = 10;
-    m_rot.type = visualization_msgs::msg::Marker::CYLINDER;
-    m_rot.action = visualization_msgs::msg::Marker::ADD;
+    box.scale.x = sx;
+    box.scale.y = sy;
+    box.scale.z = sz;
 
-    m_rot.pose = base_pose;
-    m_rot.pose.position.z = z_center;  // centrado en la banda [z_min, z_max]
+    box.color = color;
+    box.lifetime = rclcpp::Duration(0, 200 * 1000000);  // 0.2s
 
-    // Sin rotación especial: el cilindro está alineado con z
-    // (la orientación de base_pose ya incluye el yaw del robot si quieres)
-    // m_rot.pose.orientation = base_pose.orientation;
-
-    m_rot.scale.x = 2.0 * r_max_rot;
-    m_rot.scale.y = 2.0 * r_max_rot;
-    m_rot.scale.z = z_height;
-
-    m_rot.color = color;
-    m_rot.lifetime = rclcpp::Duration(0, 200 * 1000000);  // 0.2 s
-
-    array.markers.push_back(m_rot);
+    array.markers.push_back(box);
   }
 
-  // ------------------------------------------------------------------
-  // 2) Volumen de TRASLACIÓN: cápsula alineada con la velocidad
-  // ------------------------------------------------------------------
-  if (v_norm >= linear_speed_min_threshold_) {
-    const double r = robot_radius_;
+  // 2) PUNTOS: la nube filtrada que realmente se usa en la detección
+  {
+    visualization_msgs::msg::Marker pts;
+    pts.header.frame_id = motion_frame_;
+    pts.header.stamp = stamp;
+    pts.ns = "collision_zone";
+    pts.id = 2;
+    pts.type = visualization_msgs::msg::Marker::SPHERE_LIST;
+    pts.action = visualization_msgs::msg::Marker::ADD;
 
-    const double dx = vx / v_norm;
-    const double dy = vy / v_norm;
+    pts.pose.orientation.w = 1.0;  // sin transformación extra
 
-    // longitud del cilindro (parte "recta" de la cápsula)
-    const double length = d_stop;
+    // Tamaño de cada esfera/punto
+    const float point_scale = 0.03f;
+    pts.scale.x = point_scale;
+    pts.scale.y = point_scale;
+    pts.scale.z = point_scale;
 
-    // 2.1. Parte cilíndrica
-    {
-      visualization_msgs::msg::Marker m;
-      m.header.frame_id = motion_frame_;
-      m.header.stamp = stamp;
-      m.ns = "collision_zone";
-      m.id = 1;
-      m.type = visualization_msgs::msg::Marker::CYLINDER;
-      m.action = visualization_msgs::msg::Marker::ADD;
+    // Color igual que el cubo (verde/rojo según colisión)
+    pts.color = color;
+    pts.lifetime = rclcpp::Duration(0, 200 * 1000000);
 
-      m.pose = base_pose;
-      m.pose.position.x += dx * (length * 0.5);
-      m.pose.position.y += dy * (length * 0.5);
-      m.pose.position.z = z_center;
-
-      const double yaw = std::atan2(dy, dx);
-      tf2::Quaternion q;
-      q.setRPY(0.0, 0.0, yaw);
-      m.pose.orientation = tf2::toMsg(q);
-
-      m.scale.x = 2.0 * r;
-      m.scale.y = 2.0 * r;
-      m.scale.z = z_height;
-
-      m.color = color;
-      m.lifetime = rclcpp::Duration(0, 200 * 1000000);
-
-      array.markers.push_back(m);
+    pts.points.reserve(cloud.points.size());
+    for (const auto & p : cloud.points) {
+      if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
+        continue;
+      }
+      geometry_msgs::msg::Point gp;
+      gp.x = p.x;
+      gp.y = p.y;
+      gp.z = p.z;
+      pts.points.push_back(gp);
     }
 
-    // 2.2. Casquete delantero (semiesfera)
-    {
-      visualization_msgs::msg::Marker m;
-      m.header.frame_id = motion_frame_;
-      m.header.stamp = stamp;
-      m.ns = "collision_zone";
-      m.id = 2;
-      m.type = visualization_msgs::msg::Marker::SPHERE;
-      m.action = visualization_msgs::msg::Marker::ADD;
-
-      m.pose = base_pose;
-      m.pose.position.x += dx * length;
-      m.pose.position.y += dy * length;
-      m.pose.position.z = z_center;
-
-      m.scale.x = 2.0 * r;
-      m.scale.y = 2.0 * r;
-      m.scale.z = z_height;
-
-      m.color = color;
-      m.lifetime = rclcpp::Duration(0, 200 * 1000000);
-
-      array.markers.push_back(m);
-    }
-
-    // Nota: no dibujamos esfera trasera para que el volumen
-    // se parezca más a lo que realmente evalúa is_inminent_collision.
+    array.markers.push_back(pts);
   }
 
   collision_marker_pub_->publish(array);
 }
-
 
 }  // namespace easynav

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -21,16 +21,31 @@
 /// \brief Implementation of the abstract base class ControllerMethodBase.
 
 #include "geometry_msgs/msg/twist_stamped.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
+
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_common/YTSession.hpp"
 
 #include "easynav_core/MethodBase.hpp"
-
 #include "easynav_core/ControllerMethodBase.hpp"
+
+#include "easynav_common/types/PointPerception.hpp"
 
 namespace easynav
 {
+
+std::expected<void, std::string>
+ControllerMethodBase::initialize(
+  const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
+  const std::string & plugin_name,
+  const std::string & tf_prefix)
+{
+  parent_node->create_publisher<visualization_msgs::msg::MarkerArray>("collision_area", 10);
+
+  return MethodBase::initialize(parent_node, plugin_name, tf_prefix);
+}
 
 bool
 ControllerMethodBase::internal_update_rt(NavState & nav_state, bool trigger)
@@ -39,10 +54,326 @@ ControllerMethodBase::internal_update_rt(NavState & nav_state, bool trigger)
     EASYNAV_TRACE_EVENT;
 
     update_rt(nav_state);
+
+    if (is_inminent_collision(nav_state)) {
+       on_inminent_collision(nav_state);
+    }
+
     return true;
   } else {
     return false;
   }
 }
+
+
+void
+ControllerMethodBase::on_inminent_collision(NavState & nav_state)
+{
+
+  RCLCPP_WARN_THROTTLE(
+    get_node()->get_logger(), *get_node()->get_clock(), 1000,
+    "ControllerMethodBase::on_inminent_collision: Inminent collision!! Stopping");
+  nav_state.set("cmd_vel", geometry_msgs::msg::TwistStamped());
+}
+
+
+bool
+ControllerMethodBase::is_inminent_collision(NavState & nav_state)
+{
+  std::cerr << "[COLLISION] ========================================" << std::endl;
+  if (!nav_state.has("cmd_vel")) {
+    std::cerr << "[COLLISION] No cmd_vel in NavState\n";
+    return false;
+  }
+  if (!nav_state.has("points")) {
+    std::cerr << "[COLLISION] No point perceptions in NavState\n";
+    return false;
+  }
+
+  const auto twist = nav_state.get<geometry_msgs::msg::TwistStamped>("cmd_vel");
+  const auto & perceptions = nav_state.get<PointPerceptions>("points");
+
+  if (perceptions.empty()) {
+    std::cerr << "[COLLISION] Perceptions empty\n";
+    return false;
+  }
+
+  const double vx = twist.twist.linear.x;
+  const double vy = twist.twist.linear.y;
+  const double wz = twist.twist.angular.z;
+  const double v_norm = std::sqrt(vx * vx + vy * vy);
+
+  // Early-out solo si el robot está prácticamente estático (sin avanzar ni girar)
+  if (v_norm < linear_speed_min_threshold_ &&
+      std::fabs(wz) < angular_speed_min_threshold_) {
+    std::cerr << "[COLLISION] Robot almost static (v≈0, w≈0) → no collision\n";
+    return false;
+  }
+
+
+  const double a_brake = std::max(brake_acc_, 1e-3);
+  const double d_stop = (v_norm * v_norm) / (2.0 * a_brake) + safety_margin_;
+
+  std::cerr << "[COLLISION] vx=" << vx
+            << " vy=" << vy
+            << " wz=" << wz
+            << " |v|=" << v_norm
+            << " d_stop=" << d_stop << "\n";
+
+  std::vector<double> min({
+    static_cast<double>(-robot_radius_ - safety_margin_),
+    static_cast<double>(-robot_radius_ - safety_margin_),
+    static_cast<double>(z_min_filter_)});
+   std::vector<double> max({
+    static_cast<double>(robot_radius_ + safety_margin_ +
+      std::max(0.0, v_norm * v_norm / (2.0 * std::max(brake_acc_, 1e-3)))),
+    static_cast<double>(robot_radius_ + safety_margin_),
+    static_cast<double>(robot_height_)});
+
+  std::cerr << "[COLLISION] Filter box min=[" << min[0] << ", " << min[1] << ", " << min[2]
+            << "] max=[" << max[0] << ", " << max[1] << ", " << max[2] << "]\n";
+
+  const auto & cloud = PointPerceptionsOpsView(perceptions)
+    .downsample(downsample_leaf_size_)
+    .filter({-2.0, -2.0, -1.0}, {2.0, 2.0, 3.0})
+    .fuse(motion_frame_)
+    ->filter(min, max)
+    .as_points();
+
+  std::cerr << "[COLLISION] Cloud size after fuse/filter: "
+            << cloud.size() << "\n";
+
+  if (cloud.empty()) {return false;}
+
+  //
+  // Rotational branch
+  //
+  if (v_norm < linear_speed_min_threshold_ &&
+      std::fabs(wz) > angular_speed_min_threshold_) {
+
+    std::cerr << "[COLLISION] Entering rotation check: v_norm=" << v_norm
+              << " wz=" << wz << "\n";
+
+    const double r_max_rot = robot_radius_ + rot_safety_margin_;
+    const double r_max_rot_sq = r_max_rot * r_max_rot;
+
+    for (const auto & p : cloud.points) {
+      if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
+        std::cerr << "[COLLISION] Skipping invalid point (NaN/Inf) in ROT: ("
+                  << p.x << "," << p.y << "," << p.z << ")\n";
+        continue;
+      }
+
+      if (p.z < z_min_filter_ || p.z > robot_height_) {continue;}
+
+      const double r_sq = static_cast<double>(p.x) * p.x +
+                          static_cast<double>(p.y) * p.y;
+
+      if (r_sq <= r_max_rot_sq) {
+        std::cerr << "[COLLISION] ROT hit at point (" << p.x << ", " << p.y << ", " << p.z
+                  << ") r_sq=" << r_sq << " <= " << r_max_rot_sq << "\n";
+        return true;
+      }
+    }
+
+    std::cerr << "[COLLISION] Rotation: no collision.\n";
+    return false;
+  }
+
+  //
+  // Translational branch
+  //
+  if (v_norm < linear_speed_min_threshold_) {
+    std::cerr << "[COLLISION] v_norm below threshold → no collision\n";
+    return false;
+  }
+
+  const double r = robot_radius_;
+  const double dx = vx / v_norm;
+  const double dy = vy / v_norm;
+  const double r_sq = r * r;
+  const double x_max = d_stop + r;
+
+  std::cerr << "[COLLISION] Entering translation check dx=" << dx
+            << " dy=" << dy
+            << " x_max=" << x_max << "\n";
+
+  for (const auto & p : cloud.points) {
+    if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
+      std::cerr << "[COLLISION] Skipping invalid point (NaN/Inf) in LIN: ("
+                << p.x << "," << p.y << "," << p.z << ")\n";
+      continue;
+    }
+    if (p.z < z_min_filter_ || p.z > robot_height_) {continue;}
+
+    const double px = p.x;
+    const double py = p.y;
+
+    const double x_prime =  dx * px + dy * py;
+    const double y_prime = -dy * px + dx * py;
+
+    if (x_prime <= 0.0 || x_prime > x_max) {continue;}
+    if ((y_prime * y_prime) > r_sq) {continue;}
+
+    std::cerr << "[COLLISION] LIN hit: p=("
+              << px << "," << py << "," << p.z
+              << ") x'=" << x_prime
+              << " y'=" << y_prime
+              << "\n";
+    return true;
+  }
+
+  std::cerr << "[COLLISION] Translation: no collision\n";
+  return false;
+}
+
+void
+ControllerMethodBase::publish_collision_zone_marker(
+  const geometry_msgs::msg::Pose & base_pose,
+  double vx, double vy, double wz,
+  double d_stop,
+  bool imminent_collision)
+{
+  if (!collision_marker_pub_) {
+    return;
+  }
+
+  visualization_msgs::msg::MarkerArray array;
+
+  // Borramos todo lo anterior de este namespace
+  {
+    visualization_msgs::msg::Marker clear;
+    clear.header.frame_id = motion_frame_;
+    clear.header.stamp = get_node()->now();
+    clear.ns = "collision_zone";
+    clear.id = 0;
+    clear.action = visualization_msgs::msg::Marker::DELETEALL;
+    array.markers.push_back(clear);
+  }
+
+  const rclcpp::Time stamp = get_node()->now();
+
+  // Color según si hay colisión inminente
+  std_msgs::msg::ColorRGBA color;
+  color.r = imminent_collision ? 1.0f : 0.0f;
+  color.g = imminent_collision ? 0.0f : 1.0f;
+  color.b = 0.0f;
+  color.a = 0.25f;  // semitransparente
+
+  const double v_norm = std::sqrt(vx * vx + vy * vy);
+
+  // Altura exacta del volumen que usa is_inminent_collision
+  const double z_min = z_min_filter_;
+  const double z_max = robot_height_;
+  const double z_center = 0.5 * (z_min + z_max);
+  const double z_height = z_max - z_min;
+
+  // ------------------------------------------------------------------
+  // 1) Volumen de ROTACIÓN: disco/cilindro alrededor del robot
+  // ------------------------------------------------------------------
+  if (v_norm < linear_speed_min_threshold_ &&
+      std::fabs(wz) > angular_speed_min_threshold_) {
+
+    const double r_max_rot = robot_radius_ + rot_safety_margin_;
+
+    visualization_msgs::msg::Marker m_rot;
+    m_rot.header.frame_id = motion_frame_;
+    m_rot.header.stamp = stamp;
+    m_rot.ns = "collision_zone";
+    m_rot.id = 10;
+    m_rot.type = visualization_msgs::msg::Marker::CYLINDER;
+    m_rot.action = visualization_msgs::msg::Marker::ADD;
+
+    m_rot.pose = base_pose;
+    m_rot.pose.position.z = z_center;  // centrado en la banda [z_min, z_max]
+
+    // Sin rotación especial: el cilindro está alineado con z
+    // (la orientación de base_pose ya incluye el yaw del robot si quieres)
+    // m_rot.pose.orientation = base_pose.orientation;
+
+    m_rot.scale.x = 2.0 * r_max_rot;
+    m_rot.scale.y = 2.0 * r_max_rot;
+    m_rot.scale.z = z_height;
+
+    m_rot.color = color;
+    m_rot.lifetime = rclcpp::Duration(0, 200 * 1000000);  // 0.2 s
+
+    array.markers.push_back(m_rot);
+  }
+
+  // ------------------------------------------------------------------
+  // 2) Volumen de TRASLACIÓN: cápsula alineada con la velocidad
+  // ------------------------------------------------------------------
+  if (v_norm >= linear_speed_min_threshold_) {
+    const double r = robot_radius_;
+
+    const double dx = vx / v_norm;
+    const double dy = vy / v_norm;
+
+    // longitud del cilindro (parte "recta" de la cápsula)
+    const double length = d_stop;
+
+    // 2.1. Parte cilíndrica
+    {
+      visualization_msgs::msg::Marker m;
+      m.header.frame_id = motion_frame_;
+      m.header.stamp = stamp;
+      m.ns = "collision_zone";
+      m.id = 1;
+      m.type = visualization_msgs::msg::Marker::CYLINDER;
+      m.action = visualization_msgs::msg::Marker::ADD;
+
+      m.pose = base_pose;
+      m.pose.position.x += dx * (length * 0.5);
+      m.pose.position.y += dy * (length * 0.5);
+      m.pose.position.z = z_center;
+
+      const double yaw = std::atan2(dy, dx);
+      tf2::Quaternion q;
+      q.setRPY(0.0, 0.0, yaw);
+      m.pose.orientation = tf2::toMsg(q);
+
+      m.scale.x = 2.0 * r;
+      m.scale.y = 2.0 * r;
+      m.scale.z = z_height;
+
+      m.color = color;
+      m.lifetime = rclcpp::Duration(0, 200 * 1000000);
+
+      array.markers.push_back(m);
+    }
+
+    // 2.2. Casquete delantero (semiesfera)
+    {
+      visualization_msgs::msg::Marker m;
+      m.header.frame_id = motion_frame_;
+      m.header.stamp = stamp;
+      m.ns = "collision_zone";
+      m.id = 2;
+      m.type = visualization_msgs::msg::Marker::SPHERE;
+      m.action = visualization_msgs::msg::Marker::ADD;
+
+      m.pose = base_pose;
+      m.pose.position.x += dx * length;
+      m.pose.position.y += dy * length;
+      m.pose.position.z = z_center;
+
+      m.scale.x = 2.0 * r;
+      m.scale.y = 2.0 * r;
+      m.scale.z = z_height;
+
+      m.color = color;
+      m.lifetime = rclcpp::Duration(0, 200 * 1000000);
+
+      array.markers.push_back(m);
+    }
+
+    // Nota: no dibujamos esfera trasera para que el volumen
+    // se parezca más a lo que realmente evalúa is_inminent_collision.
+  }
+
+  collision_marker_pub_->publish(array);
+}
+
 
 }  // namespace easynav

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -48,27 +48,26 @@ ControllerMethodBase::initialize(
   collision_marker_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
     "collision_area", 10);
 
-  node->declare_parameter(ns + ".colision_checker.active", collision_checker_active_);
-  node->declare_parameter(ns + ".colision_checker.debug_markers", debug_markers_);
-  node->declare_parameter(ns + ".colision_checker.robot_radius", robot_radius_);
-  node->declare_parameter(ns + ".colision_checker.robot_height", robot_height_);
-  node->declare_parameter(ns + ".colision_checker.brake_acc", brake_acc_);
-  node->declare_parameter(ns + ".colision_checker.safety_margin", safety_margin_);
-  node->declare_parameter(ns + ".colision_checker.z_min_filter", z_min_filter_);
-  node->declare_parameter(ns + ".colision_checker.downsample_leaf_size", downsample_leaf_size_);
-  node->declare_parameter(ns + ".colision_checker.motion_frame", motion_frame_);
+  node->declare_parameter("colision_checker.active", collision_checker_active_);
+  node->declare_parameter("colision_checker.debug_markers", debug_markers_);
+  node->declare_parameter("colision_checker.robot_radius", robot_radius_);
+  node->declare_parameter("colision_checker.robot_height", robot_height_);
+  node->declare_parameter("colision_checker.brake_acc", brake_acc_);
+  node->declare_parameter("colision_checker.safety_margin", safety_margin_);
+  node->declare_parameter("colision_checker.z_min_filter", z_min_filter_);
+  node->declare_parameter("colision_checker.downsample_leaf_size", downsample_leaf_size_);
+  node->declare_parameter("colision_checker.motion_frame", motion_frame_);
 
-  node->get_parameter(ns + ".colision_checker.active", collision_checker_active_);
-  node->get_parameter(ns + ".colision_checker.debug_markers", debug_markers_);
-  node->get_parameter(ns + ".colision_checker.robot_radius", robot_radius_);
-  node->get_parameter(ns + ".colision_checker.robot_height", robot_height_);
-  node->get_parameter(ns + ".colision_checker.brake_acc", brake_acc_);
-  node->get_parameter(ns + ".colision_checker.safety_margin", safety_margin_);
-  node->get_parameter(ns + ".colision_checker.z_min_filter", z_min_filter_);
-  node->get_parameter(ns + ".colision_checker.downsample_leaf_size", downsample_leaf_size_);
-  node->get_parameter(ns + ".colision_checker.motion_frame", motion_frame_);
+  node->get_parameter("colision_checker.active", collision_checker_active_);
+  node->get_parameter("colision_checker.debug_markers", debug_markers_);
+  node->get_parameter("colision_checker.robot_radius", robot_radius_);
+  node->get_parameter("colision_checker.robot_height", robot_height_);
+  node->get_parameter("colision_checker.brake_acc", brake_acc_);
+  node->get_parameter("colision_checker.safety_margin", safety_margin_);
+  node->get_parameter("colision_checker.z_min_filter", z_min_filter_);
+  node->get_parameter("colision_checker.downsample_leaf_size", downsample_leaf_size_);
+  node->get_parameter("colision_checker.motion_frame", motion_frame_);
 
-  return MethodBase::initialize(parent_node, plugin_name, tf_prefix);
   return MethodBase::initialize(parent_node, plugin_name, tf_prefix);
 }
 
@@ -80,7 +79,7 @@ ControllerMethodBase::internal_update_rt(NavState & nav_state, bool trigger)
 
     update_rt(nav_state);
 
-    if (is_inminent_collision(nav_state)) {
+    if (collision_checker_active_ && is_inminent_collision(nav_state)) {
       on_inminent_collision(nav_state);
     }
 
@@ -103,6 +102,7 @@ ControllerMethodBase::on_inminent_collision(NavState & nav_state)
 bool
 ControllerMethodBase::is_inminent_collision(NavState & nav_state)
 {
+  EASYNAV_TRACE_EVENT;
   bool imminent = false;
 
   if (!nav_state.has("cmd_vel")) {return false;}
@@ -120,6 +120,7 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
 
   const double a_brake = std::max(brake_acc_, 1e-3);
   const double d_stop = (v_norm * v_norm) / (2.0 * a_brake) + safety_margin_;
+  const double t_stop = v_norm / a_brake;
 
   std::vector<double> min({
       static_cast<double>(-robot_radius_ - safety_margin_),
@@ -131,12 +132,18 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
       static_cast<double>(robot_radius_ + safety_margin_),
       static_cast<double>(robot_height_)});
 
+  auto t0 = get_node()->now();
+
   const auto & cloud = PointPerceptionsOpsView(perceptions)
     .downsample(downsample_leaf_size_)
-    .filter({-2.0, -2.0, z_min_filter_}, {2.0, 2.0, robot_height_})
+    //.filter({-1.2, -1.2, -1.2}, {1.2, 1.2, 1.2})
     .fuse(motion_frame_)
     ->filter(min, max)
     .as_points();
+
+  auto t1 = get_node()->now();
+  std::cerr << "t1 = " << std::fixed << std::setprecision(8) << (t1-t0).seconds() << std::endl;
+  std::cerr << "points = " <<  cloud.size() << std::endl;
 
   if (cloud.empty()) {
     publish_collision_zone_marker(min, max, cloud, imminent);
@@ -152,22 +159,44 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
   const double r_sq = r * r;
   const double x_max = d_stop + r;
 
+  auto t2 = get_node()->now();
+  std::cerr << "t2 = " << std::fixed << std::setprecision(8) << (t2-t1).seconds() << std::endl;
+
   for (const auto & p : cloud.points) {
     if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {continue;}
 
     const double px = p.x;
     const double py = p.y;
 
-    const double x_prime = dx * px + dy * py;
-    const double y_prime = -dy * px + dx * py;
+    const double v_rel_x = -vx + wz * py;
+    const double v_rel_y = -vy - wz * px;
 
-    if (x_prime <= 0.0 || x_prime > x_max) {continue;}
-    if ((y_prime * y_prime) > r_sq) {continue;}
+    const double v_rel_sq = v_rel_x * v_rel_x + v_rel_y * v_rel_y;
+    if (v_rel_sq < 1e-8) {continue;}
 
-    imminent = true;
-    publish_collision_zone_marker(min, max, cloud, imminent);
-    return imminent;
+    const double dot = px * v_rel_x + py * v_rel_y;
+    const double t_star = -dot / v_rel_sq;
+
+    if (t_star < 0.0) {continue;}
+    if (t_star > t_stop) {continue;}
+
+    const double cx = px + v_rel_x * t_star;
+    const double cy = py + v_rel_y * t_star;
+    const double d_min_sq = cx * cx + cy * cy;
+
+    if (d_min_sq <= r_sq) {
+      imminent = true;
+      publish_collision_zone_marker(min, max, cloud, imminent);
+      
+      auto t3 = get_node()->now();
+      std::cerr << "t3 = " << std::fixed << std::setprecision(8) << (t3-t2).seconds() << std::endl;
+
+      return true;
+    }
   }
+  auto t3 = get_node()->now();
+  std::cerr << "t3 = " << std::fixed << std::setprecision(8) << (t3-t2).seconds() << std::endl;
+
   publish_collision_zone_marker(min, max, cloud, imminent);
   return imminent;
 }

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -42,12 +42,33 @@ ControllerMethodBase::initialize(
   const std::string & plugin_name,
   const std::string & tf_prefix)
 {
-  collision_marker_pub_ = parent_node->create_publisher<visualization_msgs::msg::MarkerArray>(
+  auto node = parent_node;
+  const auto & ns = plugin_name;
+
+  collision_marker_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
     "collision_area", 10);
 
+  node->declare_parameter(ns + ".colision_checker.active", collision_checker_active_);
+  node->declare_parameter(ns + ".colision_checker.debug_markers", debug_markers_);
+  node->declare_parameter(ns + ".colision_checker.robot_radius", robot_radius_);
+  node->declare_parameter(ns + ".colision_checker.robot_height", robot_height_);
+  node->declare_parameter(ns + ".colision_checker.brake_acc", brake_acc_);
+  node->declare_parameter(ns + ".colision_checker.safety_margin", safety_margin_);
+  node->declare_parameter(ns + ".colision_checker.z_min_filter", z_min_filter_);
+  node->declare_parameter(ns + ".colision_checker.downsample_leaf_size", downsample_leaf_size_);
+  node->declare_parameter(ns + ".colision_checker.motion_frame", motion_frame_);
 
+  node->get_parameter(ns + ".colision_checker.active", collision_checker_active_);
+  node->get_parameter(ns + ".colision_checker.debug_markers", debug_markers_);
+  node->get_parameter(ns + ".colision_checker.robot_radius", robot_radius_);
+  node->get_parameter(ns + ".colision_checker.robot_height", robot_height_);
+  node->get_parameter(ns + ".colision_checker.brake_acc", brake_acc_);
+  node->get_parameter(ns + ".colision_checker.safety_margin", safety_margin_);
+  node->get_parameter(ns + ".colision_checker.z_min_filter", z_min_filter_);
+  node->get_parameter(ns + ".colision_checker.downsample_leaf_size", downsample_leaf_size_);
+  node->get_parameter(ns + ".colision_checker.motion_frame", motion_frame_);
 
-
+  return MethodBase::initialize(parent_node, plugin_name, tf_prefix);
   return MethodBase::initialize(parent_node, plugin_name, tf_prefix);
 }
 
@@ -60,7 +81,7 @@ ControllerMethodBase::internal_update_rt(NavState & nav_state, bool trigger)
     update_rt(nav_state);
 
     if (is_inminent_collision(nav_state)) {
-       on_inminent_collision(nav_state);
+      on_inminent_collision(nav_state);
     }
 
     return true;
@@ -82,60 +103,33 @@ ControllerMethodBase::on_inminent_collision(NavState & nav_state)
 bool
 ControllerMethodBase::is_inminent_collision(NavState & nav_state)
 {
-  std::cerr << "[COLLISION] ========================================" << std::endl;
-
   bool imminent = false;
 
-  if (!nav_state.has("cmd_vel")) {
-    std::cerr << "[COLLISION] No cmd_vel in NavState\n";
-    return false;
-  }
-  if (!nav_state.has("points")) {
-    std::cerr << "[COLLISION] No point perceptions in NavState\n";
-    return false;
-  }
+  if (!nav_state.has("cmd_vel")) {return false;}
+  if (!nav_state.has("points")) {return false;}
 
   const auto twist = nav_state.get<geometry_msgs::msg::TwistStamped>("cmd_vel");
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
-  if (perceptions.empty()) {
-    std::cerr << "[COLLISION] Perceptions empty\n";
-    return false;
-  }
+  if (perceptions.empty()) {return false;}
 
   const double vx = twist.twist.linear.x;
   const double vy = twist.twist.linear.y;
   const double wz = twist.twist.angular.z;
   const double v_norm = std::sqrt(vx * vx + vy * vy);
 
-  // Early-out solo si el robot está prácticamente estático (sin avanzar ni girar)
-  if (v_norm < linear_speed_min_threshold_ &&
-      std::fabs(wz) < angular_speed_min_threshold_) {
-    std::cerr << "[COLLISION] Robot almost static (v≈0, w≈0) → no collision\n";
-    return false;
-  }
-
   const double a_brake = std::max(brake_acc_, 1e-3);
   const double d_stop = (v_norm * v_norm) / (2.0 * a_brake) + safety_margin_;
 
-  std::cerr << "[COLLISION] vx=" << vx
-            << " vy=" << vy
-            << " wz=" << wz
-            << " |v|=" << v_norm
-            << " d_stop=" << d_stop << "\n";
-
   std::vector<double> min({
-    static_cast<double>(-robot_radius_ - safety_margin_),
-    static_cast<double>(-robot_radius_ - safety_margin_),
-    static_cast<double>(z_min_filter_)});
+      static_cast<double>(-robot_radius_ - safety_margin_),
+      static_cast<double>(-robot_radius_ - safety_margin_),
+      static_cast<double>(z_min_filter_)});
   std::vector<double> max({
-    static_cast<double>(robot_radius_ + safety_margin_ +
+      static_cast<double>(robot_radius_ + safety_margin_ +
       std::max(0.0, v_norm * v_norm / (2.0 * std::max(brake_acc_, 1e-3)))),
-    static_cast<double>(robot_radius_ + safety_margin_),
-    static_cast<double>(robot_height_)});
-
-  std::cerr << "[COLLISION] Filter box min=[" << min[0] << ", " << min[1] << ", " << min[2]
-            << "] max=[" << max[0] << ", " << max[1] << ", " << max[2] << "]\n";
+      static_cast<double>(robot_radius_ + safety_margin_),
+      static_cast<double>(robot_height_)});
 
   const auto & cloud = PointPerceptionsOpsView(perceptions)
     .downsample(downsample_leaf_size_)
@@ -143,9 +137,6 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
     .fuse(motion_frame_)
     ->filter(min, max)
     .as_points();
-
-  std::cerr << "[COLLISION] Cloud size after fuse/filter: "
-            << cloud.size() << "\n";
 
   if (cloud.empty()) {
     publish_collision_zone_marker(min, max, cloud, imminent);
@@ -161,46 +152,22 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
   const double r_sq = r * r;
   const double x_max = d_stop + r;
 
-  std::cerr << "[COLLISION] Entering translation check dx=" << dx
-            << " dy=" << dy
-            << " r_sq=" << r_sq
-            << " x_max=" << x_max << "\n";
-
   for (const auto & p : cloud.points) {
-    if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
-      std::cerr << "[COLLISION] Skipping invalid point (NaN/Inf) in LIN: ("
-                << p.x << "," << p.y << "," << p.z << ")\n";
-      continue;
-    }
+    if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {continue;}
 
     const double px = p.x;
     const double py = p.y;
 
-    const double x_prime =  dx * px + dy * py;
+    const double x_prime = dx * px + dy * py;
     const double y_prime = -dy * px + dx * py;
-
-
-   std::cerr << "[COLLISION] Point: ("
-                << p.x << "," << p.y << "," << p.z << ")\t"
-                << "x_prime = " << x_prime << "\t"
-                << "y_prime = " << y_prime << "\t"
-                << std::endl;
 
     if (x_prime <= 0.0 || x_prime > x_max) {continue;}
     if ((y_prime * y_prime) > r_sq) {continue;}
-
-    std::cerr << "[COLLISION] LIN hit: p=("
-              << px << "," << py << "," << p.z
-              << ") x'=" << x_prime
-              << " y'=" << y_prime
-              << "\n";
 
     imminent = true;
     publish_collision_zone_marker(min, max, cloud, imminent);
     return imminent;
   }
-
-  std::cerr << "[COLLISION] Translation: no collision\n";
   publish_collision_zone_marker(min, max, cloud, imminent);
   return imminent;
 }
@@ -213,13 +180,11 @@ ControllerMethodBase::publish_collision_zone_marker(
   const pcl::PointCloud<pcl::PointXYZ> & cloud,
   bool imminent_collision)
 {
-  if (!collision_marker_pub_) {
-    return;
-  }
+  if (!debug_markers_) {return;}
+  if (!collision_marker_pub_) {return;}
 
   visualization_msgs::msg::MarkerArray array;
 
-  // 0) Borrar todo lo anterior en este namespace
   {
     visualization_msgs::msg::Marker clear;
     clear.header.frame_id = motion_frame_;
@@ -232,14 +197,12 @@ ControllerMethodBase::publish_collision_zone_marker(
 
   const rclcpp::Time stamp = get_node()->now();
 
-  // Color según colisión inminente
   std_msgs::msg::ColorRGBA color;
   color.r = imminent_collision ? 1.0f : 0.0f;
   color.g = imminent_collision ? 0.0f : 1.0f;
   color.b = 0.0f;
   color.a = 0.25f;
 
-  // 1) CUBO que representa la caja [min, max] usada en el filtro
   {
     visualization_msgs::msg::Marker box;
     box.header.frame_id = motion_frame_;
@@ -249,7 +212,6 @@ ControllerMethodBase::publish_collision_zone_marker(
     box.type = visualization_msgs::msg::Marker::CUBE;
     box.action = visualization_msgs::msg::Marker::ADD;
 
-    // Centro y tamaño del cubo
     const double cx = 0.5 * (min[0] + max[0]);
     const double cy = 0.5 * (min[1] + max[1]);
     const double cz = 0.5 * (min[2] + max[2]);
@@ -273,7 +235,6 @@ ControllerMethodBase::publish_collision_zone_marker(
     array.markers.push_back(box);
   }
 
-  // 2) PUNTOS: la nube filtrada que realmente se usa en la detección
   {
     visualization_msgs::msg::Marker pts;
     pts.header.frame_id = motion_frame_;
@@ -283,15 +244,13 @@ ControllerMethodBase::publish_collision_zone_marker(
     pts.type = visualization_msgs::msg::Marker::SPHERE_LIST;
     pts.action = visualization_msgs::msg::Marker::ADD;
 
-    pts.pose.orientation.w = 1.0;  // sin transformación extra
+    pts.pose.orientation.w = 1.0;
 
-    // Tamaño de cada esfera/punto
     const float point_scale = 0.03f;
     pts.scale.x = point_scale;
     pts.scale.y = point_scale;
     pts.scale.z = point_scale;
 
-    // Color igual que el cubo (verde/rojo según colisión)
     pts.color = color;
     pts.lifetime = rclcpp::Duration(0, 200 * 1000000);
 


### PR DESCRIPTION
Hi,

This is a draft proposal for a new collision checker for the controller. The idea is that the base class of the controller plugins stops the robot when a collision is imminent. Of course, you can disable this checker (enabled by default) or even override `on_inminent_collision` to decide what to do (by default, stop).

A configuration for the controller adds a `colision_checker` section:

 ```
controller_node:
  ros__parameters:
    use_sim_time: true
    colision_checker:
      active: true
      debug_markers: true
      robot_radius: 0.30
      brake_acc: 1.0
      safety_margin: 0.05
    controller_types: [serest]
    serest:
      rt_freq: 30.0 
 ...
```

https://github.com/user-attachments/assets/9caae423-b0e9-4644-8ec0-a0d4457d3de8

I would like to know your opinion about this...