### PR TITLE
Optimize pointperceptionview

### DIFF
--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -35,6 +35,9 @@
 #include <vector>
 #include <optional>
 
+#include "tf2_ros/buffer.hpp"
+#include "tf2_ros/transform_listener.hpp"
+
 #include "pcl_conversions/pcl_conversions.h"
 #include "pcl/point_types_conversion.h"
 #include "pcl/common/transforms.h"
@@ -174,7 +177,8 @@ PointPerceptions get_point_perceptions(std::vector<PerceptionPtr> & perceptionpt
 /// \brief Provides efficient, non-destructive, chainable operations over a set of point-based perceptions.
 ///
 /// This view enables filtering, downsampling, fusion, and dimensional collapsing across multiple point clouds
-/// without duplicating memory, by keeping index-based selections per perception.
+/// without duplicating the underlying perceptions. Most operations work lazily by keeping index-based selections
+/// and transformation options, and only materialize a new point cloud when required (for example in as_points()).
 class PointPerceptionsOpsView
 {
 public:
@@ -214,7 +218,6 @@ public:
   /// \param perceptions Constant reference to the source container.
   explicit PointPerceptionsOpsView(const PointPerceptions & perceptions);
 
-
   /// \brief Constructs a view from a single PointPerception instance.
   ///
   /// Creates an internal container owning the given perception and
@@ -222,7 +225,6 @@ public:
   ///
   /// \param perception The PointPerception to wrap in the view.
   explicit PointPerceptionsOpsView(const PointPerception & perception);
-
 
   /// \brief Constructs a view taking ownership of the container.
   /// \param perceptions Rvalue container of perceptions to be owned by the view.
@@ -244,14 +246,15 @@ public:
   /// \return Reference to \c *this to allow chaining.
   PointPerceptionsOpsView & downsample(double resolution);
 
-  /// \brief Collapses dimensions to fixed values (e.g., projection onto a plane).
+  /// \brief Configures collapsing of dimensions to fixed values (for example, projection onto a plane).
   ///
-  /// Components set to \c NaN in \p collapse_dims keep the original values.
+  /// Components set to \c NaN in \p collapse_dims keep the original values. This method does not
+  /// modify the underlying perceptions, but stores the collapsing configuration to be applied lazily
+  /// when materializing point clouds (for example in as_points()).
   ///
   /// \param collapse_dims Fixed values for each axis (use \c NaN to preserve original values).
-  /// \return A new view with collapsed points.
-  std::shared_ptr<PointPerceptionsOpsView> collapse(
-    const std::vector<double> & collapse_dims) const;
+  /// \return Reference to \c *this to allow chaining.
+  PointPerceptionsOpsView & collapse(const std::vector<double> & collapse_dims);
 
   /// \brief Retrieves all selected points across perceptions as a single concatenated cloud.
   /// \return Concatenated point cloud.
@@ -262,20 +265,35 @@ public:
   /// \return Const reference to the filtered point cloud.
   const pcl::PointCloud<pcl::PointXYZ> & as_points(int idx) const;
 
-  /// \brief Fuses all perceptions into one by transforming them to a common frame.
-  /// \param target_frame Frame ID to which all clouds are transformed.
-  /// \return New view containing the fused result.
-  std::shared_ptr<PointPerceptionsOpsView> fuse(const std::string & target_frame) const;
+  /// \brief Configures fusion of all perceptions into a common frame.
+  ///
+  /// This method does not immediately build a fused point cloud. Instead, it stores the target frame
+  /// and the required transforms so that subsequent operations (for example filter) and final
+  /// materialization (as_points()) work in \p target_frame without duplicating the underlying data.
+  ///
+  /// \param target_frame Frame ID to which all clouds are conceptually transformed.
+  /// \return Reference to \c *this to allow chaining.
+  PointPerceptionsOpsView & fuse(const std::string & target_frame);
 
-  /// \brief Adds a new perception from a point cloud and returns an extended view.
+  /// \brief Adds a new perception to the current view.
+  ///
+  /// This method extends the underlying set of perceptions managed by the view.
+  /// It does not create a new PointPerceptionsOpsView instance; instead, it
+  /// updates the current view in place and returns a reference to \c *this
+  /// to allow method chaining.
+  ///
+  /// The newly added perception becomes part of subsequent operations such as
+  /// filtering, fusion, collapsing, and final materialization (as_points()).
+  ///
   /// \param points Point cloud to include.
   /// \param frame Frame ID associated with \p points.
   /// \param stamp Timestamp associated with \p points.
-  /// \return New view including the added perception.
-  std::shared_ptr<PointPerceptionsOpsView> add(
+  /// \return Reference to \c *this to allow chaining.
+  PointPerceptionsOpsView &
+  add(
     const pcl::PointCloud<pcl::PointXYZ> points,
     const std::string & frame,
-    rclcpp::Time stamp) const;
+    rclcpp::Time stamp);
 
   /// \brief Provides a constant reference to the underlying perceptions container.
   /// \return Constant reference to the container.
@@ -285,6 +303,23 @@ private:
   std::optional<PointPerceptions> owned_;      ///< Owned container if moved in.
   const PointPerceptions & perceptions_;       ///< Reference to perception container.
   std::vector<pcl::PointIndices> indices_;     ///< Filtered indices per perception.
+
+  // Lazy fusion state
+  bool has_target_frame_ {false};              ///< True if a common target frame has been configured.
+  std::string target_frame_;                   ///< Target frame configured by fuse().
+  std::vector<tf2::Transform> tf_transforms_;  ///< Cached transforms from perception frame to target frame.
+  std::vector<bool> tf_valid_;                 ///< True if corresponding transform is valid.
+
+  // Lazy collapse state
+  bool collapse_x_ {false};                    ///< Collapse X dimension if true.
+  bool collapse_y_ {false};                    ///< Collapse Y dimension if true.
+  bool collapse_z_ {false};                    ///< Collapse Z dimension if true.
+  float collapse_val_x_ {0.0f};                ///< Value used when collapsing X (if enabled).
+  float collapse_val_y_ {0.0f};                ///< Value used when collapsing Y (if enabled).
+  float collapse_val_z_ {0.0f};                ///< Value used when collapsing Z (if enabled).
+
+  // Temporary storage for as_points(int)
+  mutable pcl::PointCloud<pcl::PointXYZ> tmp_single_cloud_;
 };
 
 }  // namespace easynav

--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -324,6 +324,12 @@ private:
   float collapse_val_y_ {0.0f};                ///< Value used when collapsing Y (if enabled).
   float collapse_val_z_ {0.0f};                ///< Value used when collapsing Z (if enabled).
 
+  bool has_post_filter_ {false};
+  double post_min_[3] {0.0, 0.0, 0.0};
+  double post_max_[3] {0.0, 0.0, 0.0};
+  bool use_post_min_[3] {false, false, false};
+  bool use_post_max_[3] {false, false, false};
+
   // Temporary storage for as_points(int)
   mutable pcl::PointCloud<pcl::PointXYZ> tmp_single_cloud_;
 };

--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -238,29 +238,57 @@ public:
 
   /// \brief Filters all point clouds by axis-aligned bounds.
   ///
-  /// Components set to \c NaN in \p min_bounds or \p max_bounds leave the corresponding axis unbounded.
+  /// When the view has no target frame configured (that is, \c fuse() has not been called),
+  /// this method always performs an eager filtering step in the original frame of each sensor,
+  /// updating the internal index sets in-place.
+  ///
+  /// When a target frame has been configured via \c fuse(), the behaviour depends on
+  /// \p lazy_post_fuse:
+  /// - If \p lazy_post_fuse is \c true (default), the bounds are stored as a post-fuse
+  ///   filter in the target frame and are applied lazily during materialization
+  ///   (for example, in \c as_points()), without modifying the internal indices.
+  /// - If \p lazy_post_fuse is \c false, the method applies the transform to the target
+  ///   frame immediately and performs an eager filtering step in that frame, updating
+  ///   the internal indices accordingly.
+  ///
+  /// Components set to \c NaN in \p min_bounds or \p max_bounds leave the corresponding
+  /// axis unbounded.
   ///
   /// \param min_bounds Minimum \c [x,y,z] values (use \c NaN to disable per axis).
   /// \param max_bounds Maximum \c [x,y,z] values (use \c NaN to disable per axis).
+  /// \param lazy_post_fuse If \c true and a target frame is set, configure a lazy
+  ///        post-fuse filter in the target frame; if \c false, always filter eagerly
+  ///        (updating indices) in the current frame (sensor or target).
   /// \return Reference to \c *this to allow chaining.
   PointPerceptionsOpsView & filter(
     const std::vector<double> & min_bounds,
-    const std::vector<double> & max_bounds);
+    const std::vector<double> & max_bounds,
+    bool lazy_post_fuse = true);
 
   /// \brief Downsamples each perception using a voxel grid.
   /// \param resolution Voxel size in meters.
   /// \return Reference to \c *this to allow chaining.
   PointPerceptionsOpsView & downsample(double resolution);
 
-  /// \brief Configures collapsing of dimensions to fixed values (for example, projection onto a plane).
+  /// \brief Collapses dimensions to fixed values (for example, projection onto a plane).
   ///
-  /// Components set to \c NaN in \p collapse_dims keep the original values. This method does not
-  /// modify the underlying perceptions, but stores the collapsing configuration to be applied lazily
-  /// when materializing point clouds (for example in as_points()).
+  /// Components set to \c NaN in \p collapse_dims keep the original values.
+  ///
+  /// The behaviour depends on \p lazy:
+  /// - If \p lazy is \c true (default), the collapse configuration is stored in the view
+  ///   and applied lazily when materializing point clouds (for example, in \c as_points()),
+  ///   without modifying the underlying perception data.
+  /// - If \p lazy is \c false and the view owns its internal container, the collapse is
+  ///   applied eagerly by updating the coordinates of all stored points, so subsequent
+  ///   operations (filters, fusion, etc.) observe the collapsed geometry.
+  ///   On non-owning views, the eager mode is ignored to avoid modifying external data.
   ///
   /// \param collapse_dims Fixed values for each axis (use \c NaN to preserve original values).
+  /// \param lazy If \c true, configure collapse lazily for output only; if \c false and the
+  ///        view is owning, apply the collapse immediately to the internal point data.
   /// \return Reference to \c *this to allow chaining.
-  PointPerceptionsOpsView & collapse(const std::vector<double> & collapse_dims);
+  PointPerceptionsOpsView &
+  collapse(const std::vector<double> & collapse_dims, bool lazy = true);
 
   /// \brief Retrieves all selected points across perceptions as a single concatenated cloud.
   /// \return Concatenated point cloud.

--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -230,6 +230,12 @@ public:
   /// \param perceptions Rvalue container of perceptions to be owned by the view.
   explicit PointPerceptionsOpsView(PointPerceptions && perceptions);
 
+  PointPerceptionsOpsView(const PointPerceptionsOpsView &) = delete;
+  PointPerceptionsOpsView & operator=(const PointPerceptionsOpsView &) = delete;
+
+  PointPerceptionsOpsView(PointPerceptionsOpsView &&) = default;
+  PointPerceptionsOpsView & operator=(PointPerceptionsOpsView &&) = default;
+
   /// \brief Filters all point clouds by axis-aligned bounds.
   ///
   /// Components set to \c NaN in \p min_bounds or \p max_bounds leave the corresponding axis unbounded.

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -203,9 +203,10 @@ PointPerceptionsOpsView::PointPerceptionsOpsView(PointPerceptions && perceptions
 PointPerceptionsOpsView &
 PointPerceptionsOpsView::filter(
   const std::vector<double> & min_bounds,
-  const std::vector<double> & max_bounds)
+  const std::vector<double> & max_bounds,
+  bool lazy_post_fuse)
 {
-  if (has_target_frame_) {
+  if (has_target_frame_ && lazy_post_fuse) {
     has_post_filter_ = true;
 
     auto fill_bounds = [](const std::vector<double> & src,
@@ -245,6 +246,12 @@ PointPerceptionsOpsView::filter(
   const double zmax = use_z_max ? max_bounds[2] : 0.0;
 
   const std::size_t n = perceptions_.size();
+  const bool has_tf_array =
+    has_target_frame_ && tf_valid_.size() == n && tf_transforms_.size() == n;
+
+  if (!lazy_post_fuse) {
+    has_post_filter_ = false;
+  }
 
   for (std::size_t i = 0; i < n; ++i) {
     const auto & pptr = perceptions_[i];
@@ -260,15 +267,25 @@ PointPerceptionsOpsView::filter(
     std::vector<int> new_indices;
     new_indices.reserve(idx_list.size());
 
+    const bool apply_tf = has_tf_array && tf_valid_[i];
+
     for (int idx : idx_list) {
       if (idx < 0 || static_cast<std::size_t>(idx) >= cloud.size()) {
         continue;
       }
 
       const auto & pt = cloud[idx];
-      const double x = pt.x;
-      const double y = pt.y;
-      const double z = pt.z;
+      double x = pt.x;
+      double y = pt.y;
+      double z = pt.z;
+
+      if (apply_tf) {
+        tf2::Vector3 p(pt.x, pt.y, pt.z);
+        p = tf_transforms_[i] * p;
+        x = p.x();
+        y = p.y();
+        z = p.z();
+      }
 
       if (use_x_min && x < xmin) {continue;}
       if (use_y_min && y < ymin) {continue;}
@@ -286,7 +303,6 @@ PointPerceptionsOpsView::filter(
 
   return *this;
 }
-
 
 PointPerceptionsOpsView &
 PointPerceptionsOpsView::downsample(double resolution)
@@ -340,21 +356,62 @@ PointPerceptionsOpsView::downsample(double resolution)
 }
 
 PointPerceptionsOpsView &
-PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims)
+PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims, bool lazy)
 {
-  collapse_x_ = collapse_dims.size() > 0 && !std::isnan(collapse_dims[0]);
-  collapse_y_ = collapse_dims.size() > 1 && !std::isnan(collapse_dims[1]);
-  collapse_z_ = collapse_dims.size() > 2 && !std::isnan(collapse_dims[2]);
+  if (lazy) {
+    collapse_x_ = collapse_dims.size() > 0 && !std::isnan(collapse_dims[0]);
+    collapse_y_ = collapse_dims.size() > 1 && !std::isnan(collapse_dims[1]);
+    collapse_z_ = collapse_dims.size() > 2 && !std::isnan(collapse_dims[2]);
 
-  if (collapse_x_) {
-    collapse_val_x_ = static_cast<float>(collapse_dims[0]);
+    if (collapse_x_) {
+      collapse_val_x_ = static_cast<float>(collapse_dims[0]);
+    }
+    if (collapse_y_) {
+      collapse_val_y_ = static_cast<float>(collapse_dims[1]);
+    }
+    if (collapse_z_) {
+      collapse_val_z_ = static_cast<float>(collapse_dims[2]);
+    }
+
+    return *this;
   }
-  if (collapse_y_) {
-    collapse_val_y_ = static_cast<float>(collapse_dims[1]);
+
+  if (!owned_.has_value()) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("PointPerceptionsOpsView"),
+      "collapse(..., lazy=false) called on a non-owning view. "
+      "Operation ignored.");
+    return *this;
   }
-  if (collapse_z_) {
-    collapse_val_z_ = static_cast<float>(collapse_dims[2]);
+
+  auto & container = owned_.value();
+
+  const bool use_x = collapse_dims.size() > 0 && !std::isnan(collapse_dims[0]);
+  const bool use_y = collapse_dims.size() > 1 && !std::isnan(collapse_dims[1]);
+  const bool use_z = collapse_dims.size() > 2 && !std::isnan(collapse_dims[2]);
+
+  const float vx = use_x ? static_cast<float>(collapse_dims[0]) : 0.0f;
+  const float vy = use_y ? static_cast<float>(collapse_dims[1]) : 0.0f;
+  const float vz = use_z ? static_cast<float>(collapse_dims[2]) : 0.0f;
+
+  if (!use_x && !use_y && !use_z) {
+    return *this;
   }
+
+  for (auto & pptr : container) {
+    if (!pptr || !pptr->valid || pptr->data.empty()) {
+      continue;
+    }
+    auto & cloud = pptr->data;
+
+    for (auto & pt : cloud) {
+      if (use_x) {pt.x = vx;}
+      if (use_y) {pt.y = vy;}
+      if (use_z) {pt.z = vz;}
+    }
+  }
+
+  collapse_x_ = collapse_y_ = collapse_z_ = false;
 
   return *this;
 }

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -142,35 +142,61 @@ points_to_rosmsg(const pcl::PointCloud<pcl::PointXYZ> & cloud)
 
 
 PointPerceptionsOpsView::PointPerceptionsOpsView(const PointPerceptions & perceptions)
-: perceptions_(perceptions), indices_(perceptions.size())
+: owned_(std::nullopt),
+  perceptions_(perceptions)
 {
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    if (perceptions_[i]) {
-      indices_[i].indices.resize(perceptions_[i]->data.size());
-      std::iota(indices_[i].indices.begin(), indices_[i].indices.end(), 0);
+  const std::size_t n = perceptions_.size();
+  indices_.resize(n);
+  tf_transforms_.resize(n);
+  tf_valid_.assign(n, false);
+
+  for (std::size_t i = 0; i < n; ++i) {
+    auto & pptr = perceptions_[i];
+    if (!pptr || !pptr->valid || pptr->data.empty()) {
+      continue;
     }
+    auto & idx = indices_[i].indices;
+    idx.resize(pptr->data.size());
+    std::iota(idx.begin(), idx.end(), 0);
   }
 }
 
 PointPerceptionsOpsView::PointPerceptionsOpsView(const PointPerception & perception)
-: owned_(std::in_place),
-  perceptions_(*owned_),
-  indices_(1)
+: owned_(PointPerceptions{}),
+  perceptions_(*owned_)
 {
   owned_->push_back(std::make_shared<PointPerception>(perception));
 
-  indices_[0].indices.resize(perceptions_[0]->data.size());
-  std::iota(indices_[0].indices.begin(), indices_[0].indices.end(), 0);
+  const std::size_t n = owned_->size();
+  indices_.resize(n);
+  tf_transforms_.resize(n);
+  tf_valid_.assign(n, false);
+
+  auto & pptr = owned_->front();
+  if (pptr && pptr->valid && !pptr->data.empty()) {
+    auto & idx = indices_.front().indices;
+    idx.resize(pptr->data.size());
+    std::iota(idx.begin(), idx.end(), 0);
+  }
 }
 
 PointPerceptionsOpsView::PointPerceptionsOpsView(PointPerceptions && perceptions)
-: owned_(std::move(perceptions)), perceptions_(*owned_), indices_(perceptions_.size())
+: owned_(std::move(perceptions)),
+  perceptions_(*owned_)
 {
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    if (!perceptions_[i] || !perceptions_[i]->valid || perceptions_[i]->data.empty()) {continue;}
+  const std::size_t n = perceptions_.size();
+  indices_.resize(n);
+  tf_transforms_.resize(n);
+  tf_valid_.assign(n, false);
 
-    indices_[i].indices.resize(perceptions_[i]->data.size());
-    std::iota(indices_[i].indices.begin(), indices_[i].indices.end(), 0);
+  for (std::size_t i = 0; i < n; ++i) {
+    auto & pptr = perceptions_[i];
+    if (!pptr || !pptr->valid || pptr->data.empty()) {
+      continue;
+    }
+    auto & idx = indices_[i].indices;
+    idx.resize(pptr->data.size());
+    std::iota(idx.begin(), idx.end(), 0);
   }
 }
 
@@ -179,29 +205,68 @@ PointPerceptionsOpsView::filter(
   const std::vector<double> & min_bounds,
   const std::vector<double> & max_bounds)
 {
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    if (!perceptions_[i] || !perceptions_[i]->valid || perceptions_[i]->data.empty()) {continue;}
+  const bool use_x_min = min_bounds.size() > 0 && !std::isnan(min_bounds[0]);
+  const bool use_y_min = min_bounds.size() > 1 && !std::isnan(min_bounds[1]);
+  const bool use_z_min = min_bounds.size() > 2 && !std::isnan(min_bounds[2]);
 
-    const auto & cloud = perceptions_[i]->data;
-    auto & indices = indices_[i].indices;
+  const bool use_x_max = max_bounds.size() > 0 && !std::isnan(max_bounds[0]);
+  const bool use_y_max = max_bounds.size() > 1 && !std::isnan(max_bounds[1]);
+  const bool use_z_max = max_bounds.size() > 2 && !std::isnan(max_bounds[2]);
 
-    std::size_t write_idx = 0;
-    for (std::size_t read_idx = 0; read_idx < indices.size(); ++read_idx) {
-      const auto & pt = cloud[indices[read_idx]];
-      bool keep = true;
-      if (!std::isnan(min_bounds[0]) && pt.x < min_bounds[0]) {keep = false;}
-      if (!std::isnan(max_bounds[0]) && pt.x > max_bounds[0]) {keep = false;}
-      if (!std::isnan(min_bounds[1]) && pt.y < min_bounds[1]) {keep = false;}
-      if (!std::isnan(max_bounds[1]) && pt.y > max_bounds[1]) {keep = false;}
-      if (!std::isnan(min_bounds[2]) && pt.z < min_bounds[2]) {keep = false;}
-      if (!std::isnan(max_bounds[2]) && pt.z > max_bounds[2]) {keep = false;}
+  const double xmin = use_x_min ? min_bounds[0] : 0.0;
+  const double ymin = use_y_min ? min_bounds[1] : 0.0;
+  const double zmin = use_z_min ? min_bounds[2] : 0.0;
 
-      if (keep) {
-        indices[write_idx++] = indices[read_idx];
-      }
+  const double xmax = use_x_max ? max_bounds[0] : 0.0;
+  const double ymax = use_y_max ? max_bounds[1] : 0.0;
+  const double zmax = use_z_max ? max_bounds[2] : 0.0;
+
+  const std::size_t n = perceptions_.size();
+
+  for (std::size_t i = 0; i < n; ++i) {
+    const auto & pptr = perceptions_[i];
+    auto & idx_list = indices_[i].indices;
+
+    if (!pptr || !pptr->valid || pptr->data.empty() || idx_list.empty()) {
+      idx_list.clear();
+      continue;
     }
 
-    indices.resize(write_idx);
+    const auto & cloud = pptr->data;
+
+    std::vector<int> new_indices;
+    new_indices.reserve(idx_list.size());
+
+    const bool apply_tf = has_target_frame_ && tf_valid_.size() == n && tf_valid_[i];
+
+    for (int idx : idx_list) {
+      if (idx < 0 || static_cast<std::size_t>(idx) >= cloud.size()) {
+        continue;
+      }
+
+      const auto & pt = cloud[idx];
+      tf2::Vector3 p(pt.x, pt.y, pt.z);
+
+      if (apply_tf) {
+        p = tf_transforms_[i] * p;
+      }
+
+      const double x = p.x();
+      const double y = p.y();
+      const double z = p.z();
+
+      if (use_x_min && x < xmin) {continue;}
+      if (use_y_min && y < ymin) {continue;}
+      if (use_z_min && z < zmin) {continue;}
+
+      if (use_x_max && x > xmax) {continue;}
+      if (use_y_max && y > ymax) {continue;}
+      if (use_z_max && z > zmax) {continue;}
+
+      new_indices.push_back(idx);
+    }
+
+    idx_list.swap(new_indices);
   }
 
   return *this;
@@ -237,43 +302,54 @@ PointPerceptionsOpsView::downsample(double resolution)
   return *this;
 }
 
-std::shared_ptr<PointPerceptionsOpsView>
-PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims) const
+PointPerceptionsOpsView &
+PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims)
 {
-  PointPerceptions result;
-  result.reserve(perceptions_.size());
+  collapse_x_ = collapse_dims.size() > 0 && !std::isnan(collapse_dims[0]);
+  collapse_y_ = collapse_dims.size() > 1 && !std::isnan(collapse_dims[1]);
+  collapse_z_ = collapse_dims.size() > 2 && !std::isnan(collapse_dims[2]);
 
-  // Precompute collapse flags and values
-  const bool collapse_x = collapse_dims.size() > 0 && !std::isnan(collapse_dims[0]);
-  const bool collapse_y = collapse_dims.size() > 1 && !std::isnan(collapse_dims[1]);
-  const bool collapse_z = collapse_dims.size() > 2 && !std::isnan(collapse_dims[2]);
+  if (collapse_x_) {
+    collapse_val_x_ = static_cast<float>(collapse_dims[0]);
+  }
+  if (collapse_y_) {
+    collapse_val_y_ = static_cast<float>(collapse_dims[1]);
+  }
+  if (collapse_z_) {
+    collapse_val_z_ = static_cast<float>(collapse_dims[2]);
+  }
 
-  const float cx = collapse_x ? static_cast<float>(collapse_dims[0]) : 0.0f;
-  const float cy = collapse_y ? static_cast<float>(collapse_dims[1]) : 0.0f;
-  const float cz = collapse_z ? static_cast<float>(collapse_dims[2]) : 0.0f;
+  return *this;
+}
 
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
+pcl::PointCloud<pcl::PointXYZ>
+PointPerceptionsOpsView::as_points() const
+{
+  pcl::PointCloud<pcl::PointXYZ> out;
+
+  std::size_t total_points = 0;
+  const std::size_t n = perceptions_.size();
+
+  for (std::size_t i = 0; i < n; ++i) {
+    total_points += indices_[i].indices.size();
+  }
+
+  out.points.reserve(total_points);
+  out.height = 1;
+  out.is_dense = false;
+
+  const bool has_tf = has_target_frame_ && tf_valid_.size() == n;
+
+  for (std::size_t i = 0; i < n; ++i) {
     const auto & pptr = perceptions_[i];
-    if (!pptr || !pptr->valid || pptr->data.empty()) {
-      continue;
-    }
-
     const auto & idx_list = indices_[i].indices;
-    if (idx_list.empty()) {
+
+    if (!pptr || !pptr->valid || pptr->data.empty() || idx_list.empty()) {
       continue;
     }
-
-    auto collapsed = std::make_shared<PointPerception>();
-    collapsed->valid = pptr->valid;
-    collapsed->frame_id = pptr->frame_id;
-    collapsed->stamp = pptr->stamp;
 
     const auto & cloud = pptr->data;
-
-    // Reserve exactly the number of points that will be added
-    collapsed->data.points.reserve(idx_list.size());
-    collapsed->data.height = 1;
-    collapsed->data.is_dense = cloud.is_dense;
+    const bool apply_tf = has_tf && tf_valid_[i];
 
     for (int idx : idx_list) {
       if (idx < 0 || static_cast<std::size_t>(idx) >= cloud.size()) {
@@ -281,154 +357,167 @@ PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims) con
       }
 
       const auto & src = cloud[idx];
-      pcl::PointXYZ dst = src;
+      tf2::Vector3 p(src.x, src.y, src.z);
 
-      if (collapse_x) {dst.x = cx;}
-      if (collapse_y) {dst.y = cy;}
-      if (collapse_z) {dst.z = cz;}
+      if (apply_tf) {
+        p = tf_transforms_[i] * p;
+      }
 
-      collapsed->data.push_back(dst);
-    }
+      pcl::PointXYZ dst(
+        static_cast<float>(p.x()),
+        static_cast<float>(p.y()),
+        static_cast<float>(p.z()));
 
-    collapsed->data.width = static_cast<uint32_t>(collapsed->data.points.size());
+      if (collapse_x_) {dst.x = collapse_val_x_;}
+      if (collapse_y_) {dst.y = collapse_val_y_;}
+      if (collapse_z_) {dst.z = collapse_val_z_;}
 
-    if (!collapsed->data.empty()) {
-      result.push_back(std::move(collapsed));
+      out.points.push_back(dst);
     }
   }
 
-  return std::make_shared<PointPerceptionsOpsView>(std::move(result));
+  out.width = static_cast<uint32_t>(out.points.size());
+  return out;
 }
 
-pcl::PointCloud<pcl::PointXYZ>
-PointPerceptionsOpsView::as_points() const
+const pcl::PointCloud<pcl::PointXYZ> &
+PointPerceptionsOpsView::as_points(int idx) const
 {
-  pcl::PointCloud<pcl::PointXYZ> output;
+  tmp_single_cloud_.clear();
+  tmp_single_cloud_.height = 1;
+  tmp_single_cloud_.is_dense = false;
 
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    auto perception = perceptions_[i];
-
-    if (!perception || !perception->valid || perception->data.empty()) {continue;}
-
-    const auto & cloud = perception->data;
-    const auto & index_list = indices_[i].indices;
-
-    for (int idx : index_list) {
-      if (static_cast<std::size_t>(idx) < cloud.size()) {
-        output.push_back(cloud[idx]);
-      }
-    }
+  if (idx < 0 || static_cast<std::size_t>(idx) >= perceptions_.size()) {
+    tmp_single_cloud_.width = 0;
+    return tmp_single_cloud_;
   }
 
-  return output;
+  const std::size_t i = static_cast<std::size_t>(idx);
+  const auto & pptr = perceptions_[i];
+  const auto & idx_list = indices_[i].indices;
+
+  if (!pptr || !pptr->valid || pptr->data.empty() || idx_list.empty()) {
+    tmp_single_cloud_.width = 0;
+    return tmp_single_cloud_;
+  }
+
+  const auto & cloud = pptr->data;
+
+  const bool has_tf = has_target_frame_ &&
+    tf_valid_.size() == perceptions_.size() &&
+    tf_valid_[i];
+
+  for (int id : idx_list) {
+    if (id < 0 || static_cast<std::size_t>(id) >= cloud.size()) {
+      continue;
+    }
+
+    const auto & src = cloud[id];
+    tf2::Vector3 p(src.x, src.y, src.z);
+
+    if (has_tf) {
+      p = tf_transforms_[i] * p;
+    }
+
+    pcl::PointXYZ dst(
+      static_cast<float>(p.x()),
+      static_cast<float>(p.y()),
+      static_cast<float>(p.z()));
+
+    if (collapse_x_) {dst.x = collapse_val_x_;}
+    if (collapse_y_) {dst.y = collapse_val_y_;}
+    if (collapse_z_) {dst.z = collapse_val_z_;}
+
+    tmp_single_cloud_.points.push_back(dst);
+  }
+
+  tmp_single_cloud_.width =
+    static_cast<uint32_t>(tmp_single_cloud_.points.size());
+  return tmp_single_cloud_;
 }
 
-std::shared_ptr<PointPerceptionsOpsView>
-PointPerceptionsOpsView::fuse(const std::string & target_frame) const
+
+PointPerceptionsOpsView &
+PointPerceptionsOpsView::fuse(const std::string & target_frame)
 {
-  auto fused = std::make_shared<PointPerception>();
-  fused->valid = true;
-  fused->frame_id = target_frame;
-  std::optional<rclcpp::Time> latest_stamp;
+  has_target_frame_ = true;
+  target_frame_ = target_frame;
 
-  // 1) Pre-compute total number of points after filters
-  std::size_t total_points = 0;
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    const auto & p = perceptions_[i];
-    if (!p || !p->valid || p->data.empty()) {continue;}
-
-    const auto & idx_list = indices_[i].indices;
-    if (idx_list.empty()) {continue;}
-
-    total_points += idx_list.size();
+  const std::size_t n = perceptions_.size();
+  if (tf_transforms_.size() != n) {
+    tf_transforms_.resize(n);
+  }
+  if (tf_valid_.size() != n) {
+    tf_valid_.assign(n, false);
   }
 
-  // Reserve memory once for the fused cloud
-  fused->data.points.reserve(total_points);
-  fused->data.height = 1;
-  fused->data.is_dense = false;
+  auto tf_buffer = easynav::RTTFBuffer::getInstance();
 
-  // 2) Transform / copy each perception into fused->data
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    const auto & p = perceptions_[i];
-    if (!p || !p->valid || p->data.empty()) {continue;}
-
-    const auto & idx_list = indices_[i].indices;
-    if (idx_list.empty()) {continue;}
-
-    const auto & cloud = p->data;
-
-    // Fast path: already in target_frame, just copy filtered points
-    if (p->frame_id == target_frame) {
-      for (int idx : idx_list) {
-        if (static_cast<std::size_t>(idx) < cloud.size()) {
-          fused->data.push_back(cloud[idx]);
-        }
-      }
-    } else {
-      // Need TF transform
-      geometry_msgs::msg::TransformStamped tf_msg;
-      try {
-        tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-          target_frame, p->frame_id,
-          tf2_ros::fromMsg(p->stamp),
-          tf2::durationFromSec(0.0));
-      } catch (const tf2::TransformException & ex) {
-        RCLCPP_WARN(
-          rclcpp::get_logger("PointPerceptionsOpsView"),
-          "TF failed: %s", ex.what());
-        continue;
-      }
-
-      tf2::Transform tf;
-      tf2::fromMsg(tf_msg.transform, tf);
-
-      for (int idx : idx_list) {
-        if (static_cast<std::size_t>(idx) >= cloud.size()) {
-          continue;
-        }
-        const auto & pt = cloud[idx];
-        tf2::Vector3 pt_tf(pt.x, pt.y, pt.z);
-        tf2::Vector3 pt_out = tf * pt_tf;
-        fused->data.emplace_back(
-          static_cast<float>(pt_out.x()),
-          static_cast<float>(pt_out.y()),
-          static_cast<float>(pt_out.z()));
-      }
+  for (std::size_t i = 0; i < n; ++i) {
+    const auto & pptr = perceptions_[i];
+    if (!pptr || !pptr->valid || pptr->data.empty()) {
+      tf_valid_[i] = false;
+      continue;
     }
 
-    if (!latest_stamp.has_value() || p->stamp > latest_stamp.value()) {
-      latest_stamp = p->stamp;
+    if (pptr->frame_id == target_frame_) {
+      tf_valid_[i] = false;
+      continue;
+    }
+
+    try {
+      auto tf_msg = tf_buffer->lookupTransform(
+        target_frame_, pptr->frame_id,
+        tf2_ros::fromMsg(pptr->stamp),
+        tf2::durationFromSec(0.0));
+
+      tf2::fromMsg(tf_msg.transform, tf_transforms_[i]);
+      tf_valid_[i] = true;
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("PointPerceptionsOpsView"),
+        "TF lookup failed in fuse(): %s", ex.what());
+      tf_valid_[i] = false;
     }
   }
 
-  fused->data.width = static_cast<uint32_t>(fused->data.points.size());
-  fused->stamp = latest_stamp.value_or(rclcpp::Time(0));
-
-  PointPerceptions result;
-  result.push_back(fused);
-
-  return std::make_shared<PointPerceptionsOpsView>(std::move(result));
+  return *this;
 }
 
-std::shared_ptr<PointPerceptionsOpsView>
+PointPerceptionsOpsView &
 PointPerceptionsOpsView::add(
   const pcl::PointCloud<pcl::PointXYZ> points,
   const std::string & frame,
-  rclcpp::Time stamp) const
+  rclcpp::Time stamp)
 {
-  auto new_perception = std::make_shared<PointPerception>();
-  new_perception->valid = true;
-  new_perception->frame_id = frame;
-  new_perception->data = points;
-  new_perception->stamp = stamp;
+  if (!owned_.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("PointPerceptionsOpsView"),
+      "add() called on a view that does not own the underlying container.");
+    return *this;
+  }
 
-  PointPerceptions new_perceptions = perceptions_;
-  new_perceptions.push_back(new_perception);
-  auto new_perception_view = std::make_shared<PointPerceptionsOpsView>(std::move(new_perceptions));
+  auto & container = owned_.value();
 
-  return new_perception_view;
+  auto p = std::make_shared<PointPerception>();
+  p->valid = true;
+  p->frame_id = frame;
+  p->stamp = stamp;
+  p->data = points;
+
+  container.push_back(p);
+
+  indices_.push_back(pcl::PointIndices{});
+  auto & idx = indices_.back().indices;
+  idx.resize(points.size());
+  std::iota(idx.begin(), idx.end(), 0);
+
+  tf_transforms_.push_back(tf2::Transform());
+  tf_valid_.push_back(false);
+
+  return *this;
 }
+
 
 PointPerceptions get_point_perceptions(std::vector<PerceptionPtr> & perceptionptr)
 {

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -275,32 +275,54 @@ PointPerceptionsOpsView::filter(
 PointPerceptionsOpsView &
 PointPerceptionsOpsView::downsample(double resolution)
 {
-  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    if (!perceptions_[i] || !perceptions_[i]->valid || perceptions_[i]->data.empty()) {continue;}
+  if (resolution <= 0.0) {
+    return *this;
+  }
 
-    const auto & cloud = perceptions_[i]->data;
+  const double inv_res = 1.0 / resolution;
+
+  std::unordered_set<VoxelKey, VoxelKeyHash> voxel_set;
+
+  const std::size_t n = perceptions_.size();
+  for (std::size_t i = 0; i < n; ++i) {
+    const auto & pptr = perceptions_[i];
+    if (!pptr || !pptr->valid || pptr->data.empty()) {
+      continue;
+    }
+
     auto & indices = indices_[i].indices;
+    if (indices.size() <= 1) {continue;}
 
-    std::unordered_set<std::tuple<int, int, int>> voxel_set;
+    const auto & cloud = pptr->data;
+
+    voxel_set.clear();
+    voxel_set.reserve(indices.size());
+
     std::size_t write_idx = 0;
 
     for (std::size_t read_idx = 0; read_idx < indices.size(); ++read_idx) {
-      const auto & pt = cloud[indices[read_idx]];
-      auto voxel = std::make_tuple(
-        static_cast<int>(pt.x / resolution),
-        static_cast<int>(pt.y / resolution),
-        static_cast<int>(pt.z / resolution));
+      const int idx = indices[read_idx];
+      if (idx < 0 || static_cast<std::size_t>(idx) >= cloud.size()) {continue;}
 
-      if (voxel_set.insert(voxel).second) {
-        indices[write_idx++] = indices[read_idx];
+      const auto & pt = cloud[idx];
+
+      const float z_val = collapse_z_ ? collapse_val_z_ : pt.z;
+
+      VoxelKey key{
+        static_cast<int>(std::floor(pt.x * inv_res)),
+        static_cast<int>(std::floor(pt.y * inv_res)),
+        static_cast<int>(std::floor(z_val * inv_res))};
+
+      if (voxel_set.insert(key).second) {
+        indices[write_idx++] = idx;
       }
     }
-
     indices.resize(write_idx);
   }
 
   return *this;
 }
+
 
 PointPerceptionsOpsView &
 PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims)

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -205,6 +205,29 @@ PointPerceptionsOpsView::filter(
   const std::vector<double> & min_bounds,
   const std::vector<double> & max_bounds)
 {
+  if (has_target_frame_) {
+    has_post_filter_ = true;
+
+    auto fill_bounds = [](const std::vector<double> & src,
+      double dst[3],
+      bool used[3]) {
+        for (int k = 0; k < 3; ++k) {
+          if (static_cast<std::size_t>(k) < src.size() && !std::isnan(src[k])) {
+            used[k] = true;
+            dst[k] = src[k];
+          } else {
+            used[k] = false;
+            dst[k] = 0.0;
+          }
+        }
+      };
+
+    fill_bounds(min_bounds, post_min_, use_post_min_);
+    fill_bounds(max_bounds, post_max_, use_post_max_);
+
+    return *this;
+  }
+
   const bool use_x_min = min_bounds.size() > 0 && !std::isnan(min_bounds[0]);
   const bool use_y_min = min_bounds.size() > 1 && !std::isnan(min_bounds[1]);
   const bool use_z_min = min_bounds.size() > 2 && !std::isnan(min_bounds[2]);
@@ -237,23 +260,15 @@ PointPerceptionsOpsView::filter(
     std::vector<int> new_indices;
     new_indices.reserve(idx_list.size());
 
-    const bool apply_tf = has_target_frame_ && tf_valid_.size() == n && tf_valid_[i];
-
     for (int idx : idx_list) {
       if (idx < 0 || static_cast<std::size_t>(idx) >= cloud.size()) {
         continue;
       }
 
       const auto & pt = cloud[idx];
-      tf2::Vector3 p(pt.x, pt.y, pt.z);
-
-      if (apply_tf) {
-        p = tf_transforms_[i] * p;
-      }
-
-      const double x = p.x();
-      const double y = p.y();
-      const double z = p.z();
+      const double x = pt.x;
+      const double y = pt.y;
+      const double z = pt.z;
 
       if (use_x_min && x < xmin) {continue;}
       if (use_y_min && y < ymin) {continue;}
@@ -271,6 +286,7 @@ PointPerceptionsOpsView::filter(
 
   return *this;
 }
+
 
 PointPerceptionsOpsView &
 PointPerceptionsOpsView::downsample(double resolution)
@@ -309,9 +325,9 @@ PointPerceptionsOpsView::downsample(double resolution)
       const float z_val = collapse_z_ ? collapse_val_z_ : pt.z;
 
       VoxelKey key{
-        static_cast<int>(std::floor(pt.x * inv_res)),
-        static_cast<int>(std::floor(pt.y * inv_res)),
-        static_cast<int>(std::floor(z_val * inv_res))};
+        static_cast<int>(pt.x * inv_res),
+        static_cast<int>(pt.y * inv_res),
+        static_cast<int>(z_val * inv_res)};
 
       if (voxel_set.insert(key).second) {
         indices[write_idx++] = idx;
@@ -322,7 +338,6 @@ PointPerceptionsOpsView::downsample(double resolution)
 
   return *this;
 }
-
 
 PointPerceptionsOpsView &
 PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims)
@@ -349,9 +364,9 @@ PointPerceptionsOpsView::as_points() const
 {
   pcl::PointCloud<pcl::PointXYZ> out;
 
-  std::size_t total_points = 0;
   const std::size_t n = perceptions_.size();
 
+  std::size_t total_points = 0;
   for (std::size_t i = 0; i < n; ++i) {
     total_points += indices_[i].indices.size();
   }
@@ -360,7 +375,8 @@ PointPerceptionsOpsView::as_points() const
   out.height = 1;
   out.is_dense = false;
 
-  const bool has_tf = has_target_frame_ && tf_valid_.size() == n;
+  const bool has_tf_array =
+    has_target_frame_ && (tf_valid_.size() == n) && (tf_transforms_.size() == n);
 
   for (std::size_t i = 0; i < n; ++i) {
     const auto & pptr = perceptions_[i];
@@ -371,7 +387,7 @@ PointPerceptionsOpsView::as_points() const
     }
 
     const auto & cloud = pptr->data;
-    const bool apply_tf = has_tf && tf_valid_[i];
+    const bool apply_tf = has_tf_array && tf_valid_[i];
 
     for (int idx : idx_list) {
       if (idx < 0 || static_cast<std::size_t>(idx) >= cloud.size()) {
@@ -385,10 +401,24 @@ PointPerceptionsOpsView::as_points() const
         p = tf_transforms_[i] * p;
       }
 
+      double x = p.x();
+      double y = p.y();
+      double z = p.z();
+
+      if (has_post_filter_) {
+        if (use_post_min_[0] && x < post_min_[0]) {continue;}
+        if (use_post_min_[1] && y < post_min_[1]) {continue;}
+        if (use_post_min_[2] && z < post_min_[2]) {continue;}
+
+        if (use_post_max_[0] && x > post_max_[0]) {continue;}
+        if (use_post_max_[1] && y > post_max_[1]) {continue;}
+        if (use_post_max_[2] && z > post_max_[2]) {continue;}
+      }
+
       pcl::PointXYZ dst(
-        static_cast<float>(p.x()),
-        static_cast<float>(p.y()),
-        static_cast<float>(p.z()));
+        static_cast<float>(x),
+        static_cast<float>(y),
+        static_cast<float>(z));
 
       if (collapse_x_) {dst.x = collapse_val_x_;}
       if (collapse_y_) {dst.y = collapse_val_y_;}

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -241,10 +241,27 @@ std::shared_ptr<PointPerceptionsOpsView>
 PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims) const
 {
   PointPerceptions result;
+  result.reserve(perceptions_.size());
+
+  // Precompute collapse flags and values
+  const bool collapse_x = collapse_dims.size() > 0 && !std::isnan(collapse_dims[0]);
+  const bool collapse_y = collapse_dims.size() > 1 && !std::isnan(collapse_dims[1]);
+  const bool collapse_z = collapse_dims.size() > 2 && !std::isnan(collapse_dims[2]);
+
+  const float cx = collapse_x ? static_cast<float>(collapse_dims[0]) : 0.0f;
+  const float cy = collapse_y ? static_cast<float>(collapse_dims[1]) : 0.0f;
+  const float cz = collapse_z ? static_cast<float>(collapse_dims[2]) : 0.0f;
 
   for (std::size_t i = 0; i < perceptions_.size(); ++i) {
     const auto & pptr = perceptions_[i];
-    if (!pptr || !pptr->valid || pptr->data.empty()) {continue;}
+    if (!pptr || !pptr->valid || pptr->data.empty()) {
+      continue;
+    }
+
+    const auto & idx_list = indices_[i].indices;
+    if (idx_list.empty()) {
+      continue;
+    }
 
     auto collapsed = std::make_shared<PointPerception>();
     collapsed->valid = pptr->valid;
@@ -252,20 +269,36 @@ PointPerceptionsOpsView::collapse(const std::vector<double> & collapse_dims) con
     collapsed->stamp = pptr->stamp;
 
     const auto & cloud = pptr->data;
-    for (int idx : indices_[i].indices) {
-      auto pt = cloud[idx];
-      if (!std::isnan(collapse_dims[0])) {pt.x = collapse_dims[0];}
-      if (!std::isnan(collapse_dims[1])) {pt.y = collapse_dims[1];}
-      if (!std::isnan(collapse_dims[2])) {pt.z = collapse_dims[2];}
-      collapsed->data.push_back(pt);
+
+    // Reserve exactly the number of points that will be added
+    collapsed->data.points.reserve(idx_list.size());
+    collapsed->data.height = 1;
+    collapsed->data.is_dense = cloud.is_dense;
+
+    for (int idx : idx_list) {
+      if (idx < 0 || static_cast<std::size_t>(idx) >= cloud.size()) {
+        continue;
+      }
+
+      const auto & src = cloud[idx];
+      pcl::PointXYZ dst = src;
+
+      if (collapse_x) {dst.x = cx;}
+      if (collapse_y) {dst.y = cy;}
+      if (collapse_z) {dst.z = cz;}
+
+      collapsed->data.push_back(dst);
     }
 
-    result.push_back(collapsed);
+    collapsed->data.width = static_cast<uint32_t>(collapsed->data.points.size());
+
+    if (!collapsed->data.empty()) {
+      result.push_back(std::move(collapsed));
+    }
   }
 
   return std::make_shared<PointPerceptionsOpsView>(std::move(result));
 }
-
 
 pcl::PointCloud<pcl::PointXYZ>
 PointPerceptionsOpsView::as_points() const
@@ -298,37 +331,78 @@ PointPerceptionsOpsView::fuse(const std::string & target_frame) const
   fused->frame_id = target_frame;
   std::optional<rclcpp::Time> latest_stamp;
 
+  // 1) Pre-compute total number of points after filters
+  std::size_t total_points = 0;
   for (std::size_t i = 0; i < perceptions_.size(); ++i) {
-    auto p = perceptions_[i];
+    const auto & p = perceptions_[i];
     if (!p || !p->valid || p->data.empty()) {continue;}
 
-    geometry_msgs::msg::TransformStamped tf_msg;
-    try {
-      tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-        target_frame, p->frame_id, tf2_ros::fromMsg(p->stamp), tf2::durationFromSec(0.0));
-    } catch (const tf2::TransformException & ex) {
-      RCLCPP_WARN(rclcpp::get_logger("PointPerceptionsOpsView"), "TF failed: %s", ex.what());
-      continue;
+    const auto & idx_list = indices_[i].indices;
+    if (idx_list.empty()) {continue;}
+
+    total_points += idx_list.size();
+  }
+
+  // Reserve memory once for the fused cloud
+  fused->data.points.reserve(total_points);
+  fused->data.height = 1;
+  fused->data.is_dense = false;
+
+  // 2) Transform / copy each perception into fused->data
+  for (std::size_t i = 0; i < perceptions_.size(); ++i) {
+    const auto & p = perceptions_[i];
+    if (!p || !p->valid || p->data.empty()) {continue;}
+
+    const auto & idx_list = indices_[i].indices;
+    if (idx_list.empty()) {continue;}
+
+    const auto & cloud = p->data;
+
+    // Fast path: already in target_frame, just copy filtered points
+    if (p->frame_id == target_frame) {
+      for (int idx : idx_list) {
+        if (static_cast<std::size_t>(idx) < cloud.size()) {
+          fused->data.push_back(cloud[idx]);
+        }
+      }
+    } else {
+      // Need TF transform
+      geometry_msgs::msg::TransformStamped tf_msg;
+      try {
+        tf_msg = RTTFBuffer::getInstance()->lookupTransform(
+          target_frame, p->frame_id,
+          tf2_ros::fromMsg(p->stamp),
+          tf2::durationFromSec(0.0));
+      } catch (const tf2::TransformException & ex) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("PointPerceptionsOpsView"),
+          "TF failed: %s", ex.what());
+        continue;
+      }
+
+      tf2::Transform tf;
+      tf2::fromMsg(tf_msg.transform, tf);
+
+      for (int idx : idx_list) {
+        if (static_cast<std::size_t>(idx) >= cloud.size()) {
+          continue;
+        }
+        const auto & pt = cloud[idx];
+        tf2::Vector3 pt_tf(pt.x, pt.y, pt.z);
+        tf2::Vector3 pt_out = tf * pt_tf;
+        fused->data.emplace_back(
+          static_cast<float>(pt_out.x()),
+          static_cast<float>(pt_out.y()),
+          static_cast<float>(pt_out.z()));
+      }
     }
-
-    tf2::Transform tf;
-    tf2::fromMsg(tf_msg.transform, tf);
-
-    pcl::PointCloud<pcl::PointXYZ> transformed;
-    for (int idx : indices_[i].indices) {
-      const auto & pt = p->data[idx];
-      tf2::Vector3 pt_tf(pt.x, pt.y, pt.z);
-      tf2::Vector3 pt_out = tf * pt_tf;
-      transformed.emplace_back(pt_out.x(), pt_out.y(), pt_out.z());
-    }
-
-    fused->data += transformed;
 
     if (!latest_stamp.has_value() || p->stamp > latest_stamp.value()) {
       latest_stamp = p->stamp;
     }
   }
 
+  fused->data.width = static_cast<uint32_t>(fused->data.points.size());
   fused->stamp = latest_stamp.value_or(rclcpp::Time(0));
 
   PointPerceptions result;

--- a/easynav_common/tests/pointperceptionsops_tests.cpp
+++ b/easynav_common/tests/pointperceptionsops_tests.cpp
@@ -100,7 +100,7 @@ TEST_F(PerceptionsOpsTest, CollapseTest)
   pcl::PointCloud<pcl::PointXYZ> collapsed =
     easynav::PointPerceptionsOpsView(perceptions)
     .collapse({NAN, NAN, 0.5})
-    ->as_points();
+    .as_points();
 
   EXPECT_EQ(collapsed.size(), 2u);
   for (const auto & pt : collapsed.points) {
@@ -196,7 +196,7 @@ TEST_F(PerceptionsOpsTest, FuseOperation)
   pcl::PointCloud<pcl::PointXYZ> fused =
     easynav::PointPerceptionsOpsView(perceptions)
     .fuse("odom")
-    ->as_points();
+    .as_points();
 
   ASSERT_EQ(fused.size(), 2u);
 
@@ -285,7 +285,7 @@ TEST(PerceptionsOpsViewCtor, FromSinglePerception_FilterDownsampleCollapse)
   auto collapsed = easynav::PointPerceptionsOpsView(p)
     .filter({0.0, 0.0, 0.0}, {1.0, 1.0, 1.0})
     .collapse({NAN, NAN, 0.25})
-    ->as_points();
+    .as_points();
   ASSERT_EQ(collapsed.size(), 8u);
   for (const auto & pt : collapsed.points) {
     EXPECT_FLOAT_EQ(pt.z, 0.25f);
@@ -325,7 +325,7 @@ TEST(PerceptionsOpsViewCtor, FromOneOfManyPerceptions_UseOneAndOperate)
   auto collapsed = easynav::PointPerceptionsOpsView(*selected)
     .filter({0.25, 0.25, 0.25}, {0.75, 0.75, 0.75})
     .collapse({NAN, NAN, 0.1})
-    ->as_points();
+    .as_points();
   ASSERT_EQ(collapsed.size(), 1u);
   EXPECT_FLOAT_EQ(collapsed[0].z, 0.1f);
 }
@@ -367,7 +367,7 @@ TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTF)
   tf_buffer->setTransform(tB, "default_authority", false);
 
   // Fuse to "odom" and check both transformed points
-  auto fused_pts = view2->fuse("odom")->as_points();
+  auto fused_pts = view2.fuse("odom").as_points();
   ASSERT_EQ(fused_pts.size(), 2u);
   EXPECT_FLOAT_EQ(fused_pts[0].x, 2.0f);
   EXPECT_FLOAT_EQ(fused_pts[1].x, 8.0f);
@@ -391,7 +391,6 @@ TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTFDense)
   // Add a second perception
   pcl::PointCloud<pcl::PointXYZ> other;
   other.emplace_back(10.f, 20.f, 30.f);
-  auto view2 = view.add(other, "sensorB", stamp);
 
   // Add a third perception
   pcl::PointCloud<pcl::PointXYZ> dense_cloud;
@@ -414,7 +413,6 @@ TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTFDense)
         dist * std::sin(elev_rad));
     }
   }
-  auto view3 = view2->add(dense_cloud, "sensorC", stamp);
 
   // Add a fourth perception
   pcl::PointCloud<pcl::PointXYZ> dense_cloud_2;
@@ -435,7 +433,10 @@ TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTFDense)
         dist * std::sin(elev_rad));
     }
   }
-  auto view4 = view3->add(dense_cloud_2, "sensorD", stamp);
+
+  view.add(other, "sensorB", stamp)
+  .add(dense_cloud, "sensorC", stamp)
+  .add(dense_cloud_2, "sensorD", stamp);
 
   // Register TFs
   geometry_msgs::msg::TransformStamped tA, tB, tC;
@@ -470,7 +471,7 @@ TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTFDense)
 
   // Fuse to "odom" and check both transformed points
   auto t_start = std::chrono::steady_clock::now();
-  auto fused_pts = view4->fuse("odom")->as_points();
+  auto fused_pts = view.fuse("odom").as_points();
   auto t_end = std::chrono::steady_clock::now();
 
   double ms =
@@ -526,8 +527,8 @@ TEST_F(PerceptionsOpsTest, CollapseDenseLidarPerformance)
   auto t_start = std::chrono::steady_clock::now();
   pcl::PointCloud<pcl::PointXYZ> collapsed =
     easynav::PointPerceptionsOpsView(perceptions)
-      .collapse({NAN, NAN, 0.5})
-      ->as_points();
+    .collapse({NAN, NAN, 0.5})
+    .as_points();
   auto t_end = std::chrono::steady_clock::now();
 
   double ms =

--- a/easynav_common/tests/pointperceptionsops_tests.cpp
+++ b/easynav_common/tests/pointperceptionsops_tests.cpp
@@ -572,7 +572,6 @@ TEST_F(PerceptionsOpsTest, CollapseDenseLidarPerformance)
 }
 
 
-
 TEST_F(PerceptionsOpsTest, All_pipeline)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_ctor_add_fuse");

--- a/easynav_common/tests/pointperceptionsops_tests.cpp
+++ b/easynav_common/tests/pointperceptionsops_tests.cpp
@@ -372,3 +372,200 @@ TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTF)
   EXPECT_FLOAT_EQ(fused_pts[0].x, 2.0f);
   EXPECT_FLOAT_EQ(fused_pts[1].x, 8.0f);
 }
+
+TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTFDense)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_ctor_add_fuse");
+  auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
+  tf2_ros::TransformListener tf_listener(*tf_buffer);
+  rclcpp::Time stamp = node->now();
+
+  easynav::PointPerception base;
+  base.valid = true;
+  base.frame_id = "sensorA";
+  base.stamp = stamp;
+  base.data.emplace_back(1.f, 2.f, 3.f);
+
+  easynav::PointPerceptionsOpsView view(base);
+
+  // Add a second perception
+  pcl::PointCloud<pcl::PointXYZ> other;
+  other.emplace_back(10.f, 20.f, 30.f);
+  auto view2 = view.add(other, "sensorB", stamp);
+
+  // Add a third perception
+  pcl::PointCloud<pcl::PointXYZ> dense_cloud;
+  dense_cloud.reserve(250000);
+  const int rings = 128;
+  const int points_per_ring = 2000;
+  for (int r = 0; r < rings; r++) {
+    float elev = -15.0f + 30.0f * (float(r) / float(rings));
+    float elev_rad = elev * M_PI / 180.0f;
+
+    for (int i = 0; i < points_per_ring; i++) {
+      float azim = float(i) * 0.18f;
+      float azim_rad = azim * M_PI / 180.0f;
+
+      float dist = 10.0f + 5.0f * std::sin(i * 0.002f);
+
+      dense_cloud.emplace_back(
+        dist * std::cos(elev_rad) * std::cos(azim_rad),
+        dist * std::cos(elev_rad) * std::sin(azim_rad),
+        dist * std::sin(elev_rad));
+    }
+  }
+  auto view3 = view2->add(dense_cloud, "sensorC", stamp);
+
+  // Add a fourth perception
+  pcl::PointCloud<pcl::PointXYZ> dense_cloud_2;
+  dense_cloud_2.reserve(250000);
+  for (int r = 0; r < rings; r++) {
+    float elev = -15.0f + 30.0f * (float(r) / float(rings));
+    float elev_rad = elev * M_PI / 180.0f;
+
+    for (int i = 0; i < points_per_ring; i++) {
+      float azim = float(i) * 0.18f;
+      float azim_rad = azim * M_PI / 180.0f;
+
+      float dist = 10.0f + 5.0f * std::sin(i * 0.002f);
+
+      dense_cloud_2.emplace_back(
+        dist * std::cos(elev_rad) * std::cos(azim_rad),
+        dist * std::cos(elev_rad) * std::sin(azim_rad),
+        dist * std::sin(elev_rad));
+    }
+  }
+  auto view4 = view3->add(dense_cloud_2, "sensorD", stamp);
+
+  // Register TFs
+  geometry_msgs::msg::TransformStamped tA, tB, tC;
+  tA.header.stamp = stamp;
+  tA.header.frame_id = "odom";
+  tA.child_frame_id = "sensorA";
+  tA.transform.translation.x = 1.0;
+  tA.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tA, "default_authority", false);
+
+  tB.header.stamp = stamp;
+  tB.header.frame_id = "odom";
+  tB.child_frame_id = "sensorB";
+  tB.transform.translation.x = -2.0;
+  tB.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tB, "default_authority", false);
+
+  tC.header.stamp = stamp;
+  tC.header.frame_id = "odom";
+  tC.child_frame_id = "sensorC";
+  tC.transform.translation.y = 1.5;
+  tC.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tC, "default_authority", false);
+
+  tC.header.stamp = stamp;
+  tC.header.frame_id = "odom";
+  tC.child_frame_id = "sensorD";
+  tC.transform.translation.y = -1.0;
+  tC.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tC, "default_authority", false);
+
+
+  // Fuse to "odom" and check both transformed points
+  auto t_start = std::chrono::steady_clock::now();
+  auto fused_pts = view4->fuse("odom")->as_points();
+  auto t_end = std::chrono::steady_clock::now();
+
+  double ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count();
+
+  RCLCPP_INFO(
+    node->get_logger(),
+    "Fuse() executed in %.2f ms with ~%zu points",
+    ms, fused_pts.size());
+
+  ASSERT_EQ(fused_pts.size(), dense_cloud.size() + dense_cloud_2.size() + 2);
+
+  EXPECT_FLOAT_EQ(fused_pts[0].x, 2.0f);  // 1 + 1
+  EXPECT_FLOAT_EQ(fused_pts[1].x, 8.0f);  // 10 - 2
+}
+
+TEST_F(PerceptionsOpsTest, CollapseDenseLidarPerformance)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_collapse_dense_lidar");
+
+  easynav::PointPerceptions perceptions;
+  auto perception = std::make_shared<easynav::PointPerception>();
+
+  perception->valid = true;
+  perception->frame_id = "sensor_lidar";
+  perception->stamp = node->now();
+
+  pcl::PointCloud<pcl::PointXYZ> dense_cloud;
+  dense_cloud.reserve(250000);
+
+  const int rings = 128;
+  const int points_per_ring = 2000;
+  for (int r = 0; r < rings; ++r) {
+    float elev_deg = -15.0f + 30.0f * (static_cast<float>(r) / static_cast<float>(rings));
+    float elev_rad = elev_deg * static_cast<float>(M_PI) / 180.0f;
+
+    for (int i = 0; i < points_per_ring; ++i) {
+      float azim_deg = static_cast<float>(i) * 0.18f;
+      float azim_rad = azim_deg * static_cast<float>(M_PI) / 180.0f;
+
+      float dist = 10.0f + 5.0f * std::sin(static_cast<float>(i) * 0.002f);
+
+      dense_cloud.emplace_back(
+        dist * std::cos(elev_rad) * std::cos(azim_rad),
+        dist * std::cos(elev_rad) * std::sin(azim_rad),
+        dist * std::sin(elev_rad));
+    }
+  }
+
+  perception->data = dense_cloud;
+  perceptions.push_back(perception);
+
+  auto t_start = std::chrono::steady_clock::now();
+  pcl::PointCloud<pcl::PointXYZ> collapsed =
+    easynav::PointPerceptionsOpsView(perceptions)
+      .collapse({NAN, NAN, 0.5})
+      ->as_points();
+  auto t_end = std::chrono::steady_clock::now();
+
+  double ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count();
+
+  RCLCPP_INFO(
+    node->get_logger(),
+    "Collapse() executed in %.2f ms with %zu input points and %zu output points",
+    ms,
+    dense_cloud.size(),
+    static_cast<std::size_t>(collapsed.size()));
+
+  EXPECT_EQ(collapsed.size(), dense_cloud.size());
+
+  ASSERT_FALSE(collapsed.empty());
+
+  const auto & src0 = dense_cloud.points[0];
+  const auto & dst0 = collapsed.points[0];
+  EXPECT_FLOAT_EQ(dst0.x, src0.x);
+  EXPECT_FLOAT_EQ(dst0.y, src0.y);
+  EXPECT_FLOAT_EQ(dst0.z, 0.5f);
+
+  const std::size_t mid_idx = collapsed.size() / 2;
+  const auto & src_mid = dense_cloud.points[mid_idx];
+  const auto & dst_mid = collapsed.points[mid_idx];
+  EXPECT_FLOAT_EQ(dst_mid.x, src_mid.x);
+  EXPECT_FLOAT_EQ(dst_mid.y, src_mid.y);
+  EXPECT_FLOAT_EQ(dst_mid.z, 0.5f);
+
+  const std::size_t last_idx = collapsed.size() - 1;
+  const auto & src_last = dense_cloud.points[last_idx];
+  const auto & dst_last = collapsed.points[last_idx];
+  EXPECT_FLOAT_EQ(dst_last.x, src_last.x);
+  EXPECT_FLOAT_EQ(dst_last.y, src_last.y);
+  EXPECT_FLOAT_EQ(dst_last.z, 0.5f);
+
+  EXPECT_EQ(perception->data.size(), dense_cloud.size());
+  EXPECT_FLOAT_EQ(perception->data[0].x, dense_cloud[0].x);
+  EXPECT_FLOAT_EQ(perception->data[0].y, dense_cloud[0].y);
+  EXPECT_FLOAT_EQ(perception->data[0].z, dense_cloud[0].z);
+}

--- a/easynav_common/tests/pointperceptionsops_tests.cpp
+++ b/easynav_common/tests/pointperceptionsops_tests.cpp
@@ -687,3 +687,192 @@ TEST_F(PerceptionsOpsTest, All_pipeline)
     "All pipeline executed in %.2f ms with ~%zu points",
     ms, fused_pts.size());
 }
+
+TEST(PerceptionsOpsViewTests, CollapseEager_OwningView_ModifiesOwnedData)
+{
+  easynav::PointPerception p;
+  p.valid = true;
+  p.frame_id = "sensor";
+  p.stamp = rclcpp::Time(0, 0);
+  p.data.emplace_back(1.0f, 2.0f, 0.9f);
+  p.data.emplace_back(1.0f, 4.0f, 1.3f);
+
+  easynav::PointPerceptionsOpsView view(p);
+
+  view.collapse({NAN, NAN, 0.5}, /*lazy=*/false);
+
+  auto collapsed = view.as_points();
+  ASSERT_EQ(collapsed.size(), 2u);
+  EXPECT_FLOAT_EQ(collapsed[0].x, 1.0f);
+  EXPECT_FLOAT_EQ(collapsed[0].z, 0.5f);
+  EXPECT_FLOAT_EQ(collapsed[1].x, 1.0f);
+  EXPECT_FLOAT_EQ(collapsed[1].z, 0.5f);
+
+  const auto & owned_perceptions = view.get_perceptions();
+  ASSERT_EQ(owned_perceptions.size(), 1u);
+  ASSERT_TRUE(owned_perceptions[0]);
+  EXPECT_FLOAT_EQ(owned_perceptions[0]->data[0].z, 0.5f);
+  EXPECT_FLOAT_EQ(owned_perceptions[0]->data[1].z, 0.5f);
+
+  EXPECT_FLOAT_EQ(p.data[0].z, 0.9f);
+  EXPECT_FLOAT_EQ(p.data[1].z, 1.3f);
+}
+
+TEST(PerceptionsOpsViewTests, CollapseEager_NonOwningView_Ignored)
+{
+  easynav::PointPerceptions perceptions;
+  auto perception = std::make_shared<easynav::PointPerception>();
+
+  perception->valid = true;
+  perception->frame_id = "sensor";
+  perception->stamp = rclcpp::Time(0, 0);
+  perception->data.emplace_back(1.0f, 2.0f, 0.9f);
+  perception->data.emplace_back(1.0f, 4.0f, 1.3f);
+  perceptions.push_back(perception);
+
+  easynav::PointPerceptionsOpsView view(perceptions);
+
+  view.collapse({NAN, NAN, 0.5}, /*lazy=*/false);
+
+  auto out = view.as_points();
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_FLOAT_EQ(out[0].z, 0.9f);
+  EXPECT_FLOAT_EQ(out[1].z, 1.3f);
+
+  EXPECT_FLOAT_EQ(perception->data[0].z, 0.9f);
+  EXPECT_FLOAT_EQ(perception->data[1].z, 1.3f);
+}
+
+TEST_F(PerceptionsOpsTest, FilterPostFuse_Lazy_AppliesInTargetFrame)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_filter_postfuse_lazy");
+  auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
+  tf2_ros::TransformListener tf_listener(*tf_buffer);
+
+  rclcpp::Time stamp = node->now();
+
+  // TF: odom -> sensor (x + 1.0)
+  geometry_msgs::msg::TransformStamped tf;
+  tf.header.stamp = stamp;
+  tf.header.frame_id = "odom";
+  tf.child_frame_id = "sensor";
+  tf.transform.translation.x = 1.0;
+  tf.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tf, "default_authority", false);
+
+  easynav::PointPerception p;
+  p.valid = true;
+  p.frame_id = "sensor";
+  p.stamp = stamp;
+  // In "sensor"
+  p.data.emplace_back(0.0f, 0.0f, 0.0f);     // in odom -> (1, 0, 0)
+  p.data.emplace_back(-0.75f, 0.0f, 0.0f);   // in odom -> (0.25, 0, 0)
+
+  easynav::PointPerceptionsOpsView view(p);
+
+  // fuse + lazy filter in odom: x >= 0.5
+  auto cloud = view
+    .fuse("odom")
+    .filter({0.5, NAN, NAN}, {NAN, NAN, NAN})  // lazy_post_fuse by default = true
+    .as_points();
+
+  ASSERT_EQ(cloud.size(), 1u);
+  EXPECT_FLOAT_EQ(cloud[0].x, 1.0f);  // onlsy the first point will survice (x=1 in odom)
+}
+
+TEST_F(PerceptionsOpsTest, FilterPostFuse_Eager_AppliesInTargetFrame)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_filter_postfuse_eager");
+  auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
+  tf2_ros::TransformListener tf_listener(*tf_buffer);
+
+  rclcpp::Time stamp = node->now();
+
+  // TF: odom -> sensor (x + 1.0)
+  geometry_msgs::msg::TransformStamped tf;
+  tf.header.stamp = stamp;
+  tf.header.frame_id = "odom";
+  tf.child_frame_id = "sensor";
+  tf.transform.translation.x = 1.0;
+  tf.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tf, "default_authority", false);
+
+  easynav::PointPerception p;
+  p.valid = true;
+  p.frame_id = "sensor";
+  p.stamp = stamp;
+  p.data.emplace_back(0.0f, 0.0f, 0.0f);     // -> (1, 0, 0) in odom
+  p.data.emplace_back(-0.75f, 0.0f, 0.0f);   // -> (0.25, 0, 0) un odom
+
+  easynav::PointPerceptionsOpsView view(p);
+
+  auto cloud = view
+    .fuse("odom")
+    .filter({0.5, NAN, NAN}, {NAN, NAN, NAN}, /*lazy_post_fuse=*/false)
+    .as_points();
+
+  ASSERT_EQ(cloud.size(), 1u);
+  EXPECT_FLOAT_EQ(cloud[0].x, 1.0f);
+}
+
+TEST_F(PerceptionsOpsTest, Filter_PreAndPostFuse_EagerCombination)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_filter_pre_post_fuse");
+  auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
+  tf2_ros::TransformListener tf_listener(*tf_buffer);
+
+  rclcpp::Time stamp = node->now();
+
+  // TF: odom -> sensor (x + 1.0)
+  geometry_msgs::msg::TransformStamped tf;
+  tf.header.stamp = stamp;
+  tf.header.frame_id = "odom";
+  tf.child_frame_id = "sensor";
+  tf.transform.translation.x = 1.0;
+  tf.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tf, "default_authority", false);
+
+  easynav::PointPerception p;
+  p.valid = true;
+  p.frame_id = "sensor";
+  p.stamp = stamp;
+  p.data.emplace_back(-1.0f, 0.0f, 0.0f);  // will disrcard in pre-fuse filter
+  p.data.emplace_back(0.0f, 0.0f, 0.0f);   // -> (1,0,0) in odom
+  p.data.emplace_back(1.0f, 0.0f, 0.0f);   // -> (2,0,0) in odom
+
+  easynav::PointPerceptionsOpsView view(p);
+
+  auto cloud = view
+    // pre-fuse filter in frame "sensor": x in [0, 1]
+    .filter({0.0, NAN, NAN}, {1.0, NAN, NAN})
+    // Fuse to "odom"
+    .fuse("odom")
+    // post-fuse eager filter: x >= 1.5 in odom
+    .filter({1.5, NAN, NAN}, {NAN, NAN, NAN}, /*lazy_post_fuse=*/false)
+    .as_points();
+
+  ASSERT_EQ(cloud.size(), 1u);
+  EXPECT_FLOAT_EQ(cloud[0].x, 2.0f);  // only the original point x=1 in sensor survives
+}
+
+TEST(PerceptionsOpsViewTests, CollapseLazy_DoesNotAffectIntermediateFilter)
+{
+  easynav::PointPerception p;
+  p.valid = true;
+  p.frame_id = "sensor";
+  p.stamp = rclcpp::Time(0, 0);
+  p.data.emplace_back(1.0f, 2.0f, 0.9f);
+  p.data.emplace_back(1.0f, 4.0f, 1.3f);
+
+  easynav::PointPerceptionsOpsView view(p);
+
+  // Collapse lazy Z=1.0
+  view.collapse({NAN, NAN, 1.0}, /*lazy=*/true);
+
+  // Filter in z [1.0, 1.0] in sensor frame: applied to original z (0.9 and 1.3),
+  // so both points are discarded.
+  view.filter({NAN, NAN, 1.0}, {NAN, NAN, 1.0});
+
+  auto cloud = view.as_points();
+  EXPECT_EQ(cloud.size(), 0u);
+}

--- a/easynav_common/tests/pointperceptionsops_tests.cpp
+++ b/easynav_common/tests/pointperceptionsops_tests.cpp
@@ -348,7 +348,7 @@ TEST_F(PerceptionsOpsTest, FromSinglePerception_AddAndFuseWithTF)
   // Add a second perception
   pcl::PointCloud<pcl::PointXYZ> other;
   other.emplace_back(10.f, 20.f, 30.f);
-  auto view2 = view.add(other, "sensorB", stamp);
+  auto & view2 = view.add(other, "sensorB", stamp);
 
   // Register TFs
   geometry_msgs::msg::TransformStamped tA, tB;
@@ -569,4 +569,122 @@ TEST_F(PerceptionsOpsTest, CollapseDenseLidarPerformance)
   EXPECT_FLOAT_EQ(perception->data[0].x, dense_cloud[0].x);
   EXPECT_FLOAT_EQ(perception->data[0].y, dense_cloud[0].y);
   EXPECT_FLOAT_EQ(perception->data[0].z, dense_cloud[0].z);
+}
+
+
+
+TEST_F(PerceptionsOpsTest, All_pipeline)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_ctor_add_fuse");
+  auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
+  tf2_ros::TransformListener tf_listener(*tf_buffer);
+  rclcpp::Time stamp = node->now();
+
+  easynav::PointPerception base;
+  base.valid = true;
+  base.frame_id = "sensorA";
+  base.stamp = stamp;
+  base.data.emplace_back(1.f, 2.f, 3.f);
+
+  easynav::PointPerceptionsOpsView view(base);
+
+  // Add a second perception
+  pcl::PointCloud<pcl::PointXYZ> other;
+  other.emplace_back(10.f, 20.f, 30.f);
+
+  // Add a third perception
+  pcl::PointCloud<pcl::PointXYZ> dense_cloud;
+  dense_cloud.reserve(250000);
+  const int rings = 128;
+  const int points_per_ring = 2000;
+  for (int r = 0; r < rings; r++) {
+    float elev = -15.0f + 30.0f * (float(r) / float(rings));
+    float elev_rad = elev * M_PI / 180.0f;
+
+    for (int i = 0; i < points_per_ring; i++) {
+      float azim = float(i) * 0.18f;
+      float azim_rad = azim * M_PI / 180.0f;
+
+      float dist = 10.0f + 5.0f * std::sin(i * 0.002f);
+
+      dense_cloud.emplace_back(
+        dist * std::cos(elev_rad) * std::cos(azim_rad),
+        dist * std::cos(elev_rad) * std::sin(azim_rad),
+        dist * std::sin(elev_rad));
+    }
+  }
+
+  // Add a fourth perception
+  pcl::PointCloud<pcl::PointXYZ> dense_cloud_2;
+  dense_cloud_2.reserve(250000);
+  for (int r = 0; r < rings; r++) {
+    float elev = -15.0f + 30.0f * (float(r) / float(rings));
+    float elev_rad = elev * M_PI / 180.0f;
+
+    for (int i = 0; i < points_per_ring; i++) {
+      float azim = float(i) * 0.18f;
+      float azim_rad = azim * M_PI / 180.0f;
+
+      float dist = 10.0f + 5.0f * std::sin(i * 0.002f);
+
+      dense_cloud_2.emplace_back(
+        dist * std::cos(elev_rad) * std::cos(azim_rad),
+        dist * std::cos(elev_rad) * std::sin(azim_rad),
+        dist * std::sin(elev_rad));
+    }
+  }
+
+  view.add(other, "sensorB", stamp)
+  .add(dense_cloud, "sensorC", stamp)
+  .add(dense_cloud_2, "sensorD", stamp);
+
+  // Register TFs
+  geometry_msgs::msg::TransformStamped tA, tB, tC;
+  tA.header.stamp = stamp;
+  tA.header.frame_id = "odom";
+  tA.child_frame_id = "sensorA";
+  tA.transform.translation.x = 1.0;
+  tA.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tA, "default_authority", false);
+
+  tB.header.stamp = stamp;
+  tB.header.frame_id = "odom";
+  tB.child_frame_id = "sensorB";
+  tB.transform.translation.x = -2.0;
+  tB.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tB, "default_authority", false);
+
+  tC.header.stamp = stamp;
+  tC.header.frame_id = "odom";
+  tC.child_frame_id = "sensorC";
+  tC.transform.translation.y = 1.5;
+  tC.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tC, "default_authority", false);
+
+  tC.header.stamp = stamp;
+  tC.header.frame_id = "odom";
+  tC.child_frame_id = "sensorD";
+  tC.transform.translation.y = -1.0;
+  tC.transform.rotation.w = 1.0;
+  tf_buffer->setTransform(tC, "default_authority", false);
+
+
+  // Fuse to "odom" and check both transformed points
+  auto t_start = std::chrono::steady_clock::now();
+  auto fused_pts = view
+    .downsample(0.1)
+    .filter({NAN, NAN, 1.0}, {NAN, NAN, 2.0})
+    .fuse("odom")
+    .filter({0.0, NAN, NAN}, {NAN, NAN, NAN})
+    .collapse({NAN, NAN, 1.0})
+    .as_points();
+  auto t_end = std::chrono::steady_clock::now();
+
+  double ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count();
+
+  RCLCPP_INFO(
+    node->get_logger(),
+    "All pipeline executed in %.2f ms with ~%zu points",
+    ms, fused_pts.size());
 }

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -349,14 +349,22 @@ SensorsNode::cycle(std::shared_ptr<NavState> nav_state)
   }
 
   if (percept_pub_->get_subscription_count() > 0) {
-    auto fused = PointPerceptionsOpsView(get_point_perceptions(perceptions_["points"]))
-      .fuse(tf_prefix_ + perception_default_frame_);
+    auto points_perceptions = get_point_perceptions(perceptions_["points"]);
 
-    auto fused_points = fused->as_points();
+    PointPerceptionsOpsView fused_view(std::move(points_perceptions));
+
+    fused_view.fuse(tf_prefix_ + perception_default_frame_);
+    auto fused_points = fused_view.as_points();
 
     auto msg = points_to_rosmsg(fused_points);
     msg.header.frame_id = tf_prefix_ + perception_default_frame_;
-    msg.header.stamp = fused->get_perceptions()[0]->stamp;
+
+    const auto & percs = fused_view.get_perceptions();
+    if (!percs.empty() && percs[0]) {
+      msg.header.stamp = percs[0]->stamp;
+    } else {
+      msg.header.stamp = now();
+    }
 
     percept_pub_->publish(msg);
   }


### PR DESCRIPTION
Hi,

This is a deep refactor of `PointPerceptionsOpsView` that **significantly** improves the processing of point operations. The key idea is the **lazy** evaluation of the costly operations, avoiding memory reservations in operations like `fuse` and `collapse`. Transforms are annotated and performed in the `as_points` method. Now all the `PointPerceptionsOpsView`  operations (even `add`) return a `PointPerceptionsOpsView &`, unifying the API.

Pipelines like:

```
  const auto & filtered = PointPerceptionsOpsView(perceptions)
    .filter({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0})
    .fuse("map")
    ->filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
    .collapse({NAN, NAN, 0.1})
    ->downsample(0.1)
    .as_points();
```
 
changes to:

```
  const auto & filtered = PointPerceptionsOpsView(perceptions)
    .filter({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0})
    .fuse("map")
    .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
    .collapse({NAN, NAN, 0.1})
    .downsample(0.1)
    .as_points();
```

The time improvements can be around 400% in some tests before and after the refactor.

