### PR TITLE
Add feedback case in sent goal state to avoid unknown msg error

### DIFF
--- a/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
+++ b/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
@@ -172,6 +172,10 @@ class GoalManagerClient:
             match self.state:
                 case ClientState.SENT_GOAL:
                     match msg.type:
+                        case NavigationControl.FEEDBACK:
+                            self.node.get_logger().debug(
+                                'Getting navigation feedback while waiting for acceptance')
+                            self.last_feedback = msg
                         case NavigationControl.ACCEPT:
                             self.node.get_logger().debug('Goal accepted. Navigating')
                             self.state = ClientState.ACCEPTED_AND_NAVIGATING
@@ -183,7 +187,7 @@ class GoalManagerClient:
                             self.state = ClientState.ERROR
                         case _:
                             self.node.get_logger().error(
-                                'State SENT_PREEMPT; Unexpected message: "%d": "%s"' %
+                                'State SENT_GOAL; Unexpected message: "%d": "%s"' %
                                 (msg.type, msg.status_message))
                             self.state = ClientState.ERROR
                 case ClientState.SENT_PREEMPT:

--- a/easynav_system/src/easynav_system/GoalManagerClient.cpp
+++ b/easynav_system/src/easynav_system/GoalManagerClient.cpp
@@ -66,6 +66,11 @@ GoalManagerClient::control_callback(easynav_interfaces::msg::NavigationControl::
       break;
     case State::SENT_GOAL:
       switch (msg->type) {
+        case easynav_interfaces::msg::NavigationControl::FEEDBACK:
+          RCLCPP_DEBUG(node_->get_logger(),
+          "Getting navigation feedback while waiting for acceptance");
+          last_feedback_ = *msg;
+          break;
         case easynav_interfaces::msg::NavigationControl::ACCEPT:
           RCLCPP_DEBUG(node_->get_logger(), "Goal accepted. Navigating");
           state_ = State::ACCEPTED_AND_NAVIGATING;


### PR DESCRIPTION
While testing the patrolling behavior, I noticed that the goal sent state in the Goal Manager Client was missing a feedback case for navigation messages. This gap caused an unexpected message error whenever the client was waiting for goal acceptance.

This PR adds a logging message to explicitly acknowledge the pending goal status, preventing that error. The update applies to both the C++ and Python implementations of the Goal Manager Client.