### PR TITLE
Cleanup unused headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.vscode/**
 **/__pycache__/
 
+# ROS 2 build files
+build/
+install/
+log/

--- a/easynav_common/include/easynav_common/RTTFBuffer.hpp
+++ b/easynav_common/include/easynav_common/RTTFBuffer.hpp
@@ -24,7 +24,6 @@
 #include "easynav_common/Singleton.hpp"
 
 #include "tf2_ros/buffer.hpp"
-#include "rclcpp/rclcpp.hpp"
 
 namespace easynav
 {

--- a/easynav_common/include/easynav_common/types/ImagePerception.hpp
+++ b/easynav_common/include/easynav_common/types/ImagePerception.hpp
@@ -29,7 +29,6 @@
 
 #include <string>
 #include <vector>
-#include <optional>
 
 #include "cv_bridge/cv_bridge.hpp"
 

--- a/easynav_common/include/easynav_common/types/PointPerception.hpp
+++ b/easynav_common/include/easynav_common/types/PointPerception.hpp
@@ -229,7 +229,6 @@ public:
   PointPerceptionsOpsView & operator=(const PointPerceptionsOpsView &) = delete;
 
   PointPerceptionsOpsView(PointPerceptionsOpsView &&) = default;
-  PointPerceptionsOpsView & operator=(PointPerceptionsOpsView &&) = default;
 
   /// \brief Filters all point clouds by axis-aligned bounds.
   ///

--- a/easynav_common/src/easynav_common/types/GNSSPerception.cpp
+++ b/easynav_common/src/easynav_common/types/GNSSPerception.cpp
@@ -23,7 +23,6 @@
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 
 #include "rclcpp/time.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "easynav_common/types/GNSSPerception.hpp"
 

--- a/easynav_common/src/easynav_common/types/PointPerception.cpp
+++ b/easynav_common/src/easynav_common/types/PointPerception.cpp
@@ -35,7 +35,6 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "easynav_common/types/PointPerception.hpp"
-#include "easynav_common/YTSession.hpp"
 #include "easynav_common/RTTFBuffer.hpp"
 
 namespace easynav

--- a/easynav_common/tests/navstate_tests.cpp
+++ b/easynav_common/tests/navstate_tests.cpp
@@ -20,7 +20,6 @@
 #include <thread>
 #include <atomic>
 #include <vector>
-#include <chrono>
 
 #include "gtest/gtest.h"
 

--- a/easynav_common/tests/pointperceptionsops_tests.cpp
+++ b/easynav_common/tests/pointperceptionsops_tests.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 #include <cmath>
 
-#include "tf2_ros/buffer.hpp"
 #include "tf2_ros/transform_listener.hpp"
 
 #include "easynav_common/types/PointPerception.hpp"

--- a/easynav_controller/src/easynav_controller/ControllerNode.cpp
+++ b/easynav_controller/src/easynav_controller/ControllerNode.cpp
@@ -27,7 +27,6 @@
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "easynav_controller/ControllerNode.hpp"
-#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -80,10 +79,8 @@ ControllerNode::~ControllerNode()
 using CallbackReturnT = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 CallbackReturnT
-ControllerNode::on_configure(const rclcpp_lifecycle::State & state)
+ControllerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   std::vector<std::string> controller_types;
   declare_parameter("controller_types", controller_types);
   get_parameter("controller_types", controller_types);
@@ -130,39 +127,32 @@ ControllerNode::on_configure(const rclcpp_lifecycle::State & state)
 }
 
 CallbackReturnT
-ControllerNode::on_activate(const rclcpp_lifecycle::State & state)
+ControllerNode::on_activate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-ControllerNode::on_deactivate(const rclcpp_lifecycle::State & state)
+ControllerNode::on_deactivate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-ControllerNode::on_cleanup(const rclcpp_lifecycle::State & state)
+ControllerNode::on_cleanup([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-ControllerNode::on_shutdown(const rclcpp_lifecycle::State & state)
+ControllerNode::on_shutdown([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-ControllerNode::on_error(const rclcpp_lifecycle::State & state)
+ControllerNode::on_error([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 

--- a/easynav_core/include/easynav_core/ControllerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/ControllerMethodBase.hpp
@@ -23,7 +23,6 @@
 #ifndef EASYNAV_CORE__CONTROLLERMETHODBASE_HPP_
 #define EASYNAV_CORE__CONTROLLERMETHODBASE_HPP_
 
-#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include "pcl/point_cloud.h"

--- a/easynav_core/include/easynav_core/LocalizerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/LocalizerMethodBase.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_CORE__LOCALIZERMETHODBASE_HPP_
 #define EASYNAV_CORE__LOCALIZERMETHODBASE_HPP_
 
-#include "nav_msgs/msg/odometry.hpp"
-
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_core/MethodBase.hpp"
 

--- a/easynav_core/include/easynav_core/MapsManagerBase.hpp
+++ b/easynav_core/include/easynav_core/MapsManagerBase.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_CORE__MAPSMANAGERBASE_HPP_
 #define EASYNAV_CORE__MAPSMANAGERBASE_HPP_
 
-#include "nav_msgs/msg/odometry.hpp"
-
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_core/MethodBase.hpp"
 

--- a/easynav_core/include/easynav_core/PlannerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/PlannerMethodBase.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_CORE__PLANNERMETHODBASE_HPP_
 #define EASYNAV_CORE__PLANNERMETHODBASE_HPP_
 
-#include "nav_msgs/msg/path.hpp"
-
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_core/MethodBase.hpp"
 

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -119,7 +119,7 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
   const double v_norm = std::sqrt(vx * vx + vy * vy);
 
   const double a_brake = std::max(brake_acc_, 1e-3);
-  const double d_stop = (v_norm * v_norm) / (2.0 * a_brake) + safety_margin_;
+  // const double d_stop = (v_norm * v_norm) / (2.0 * a_brake) + safety_margin_;
   const double t_stop = v_norm / a_brake;
 
   std::vector<double> min({
@@ -148,10 +148,10 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
   base_pose.orientation.w = 1.0;
 
   const double r = robot_radius_;
-  const double dx = vx / v_norm;
-  const double dy = vy / v_norm;
+  // const double dx = vx / v_norm;
+  // const double dy = vy / v_norm;
   const double r_sq = r * r;
-  const double x_max = d_stop + r;
+  // const double x_max = d_stop + r;
 
   for (const auto & p : cloud.points) {
     if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {continue;}

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -23,8 +23,6 @@
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_common/YTSession.hpp"
 
@@ -43,7 +41,6 @@ ControllerMethodBase::initialize(
   const std::string & tf_prefix)
 {
   auto node = parent_node;
-  const auto & ns = plugin_name;
 
   collision_marker_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
     "collision_area", 10);

--- a/easynav_core/src/easynav_core/LocalizerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/LocalizerMethodBase.cpp
@@ -20,12 +20,8 @@
 /// \file
 /// \brief Implementation of the abstract base class LocalizerMethodBase.
 
-#include "nav_msgs/msg/odometry.hpp"
-
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_common/YTSession.hpp"
-
-#include "easynav_core/MethodBase.hpp"
 
 #include "easynav_core/LocalizerMethodBase.hpp"
 

--- a/easynav_core/src/easynav_core/MapsManagerBase.cpp
+++ b/easynav_core/src/easynav_core/MapsManagerBase.cpp
@@ -20,12 +20,8 @@
 /// \file
 /// \brief Implementation of the abstract base class MapsManagerBase.
 
-#include "nav_msgs/msg/odometry.hpp"
-
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_common/YTSession.hpp"
-
-#include "easynav_core/MethodBase.hpp"
 
 #include "easynav_core/MapsManagerBase.hpp"
 

--- a/easynav_core/src/easynav_core/PlannerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/PlannerMethodBase.cpp
@@ -20,12 +20,8 @@
 /// \file
 /// \brief Implementation of the abstract base class PlannerMethodBase.
 
-#include "nav_msgs/msg/path.hpp"
-
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_common/YTSession.hpp"
-
-#include "easynav_core/MethodBase.hpp"
 
 #include "easynav_core/PlannerMethodBase.hpp"
 

--- a/easynav_core/test/core_method_test.cpp
+++ b/easynav_core/test/core_method_test.cpp
@@ -18,6 +18,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #include "gtest/gtest.h"
+#include <expected>
+
+#include "nav_msgs/msg/odometry.hpp"
 
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_core/MethodBase.hpp"

--- a/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
+++ b/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
@@ -20,7 +20,6 @@
 /// \file
 /// \brief Implementation of the DummyLocalizer class.
 
-#include <expected>
 #include "easynav_localizer/DummyLocalizer.hpp"
 
 #include "easynav_common/RTTFBuffer.hpp"

--- a/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
+++ b/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
@@ -26,7 +26,6 @@
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "easynav_localizer/LocalizerNode.hpp"
-#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -66,10 +65,8 @@ LocalizerNode::~LocalizerNode()
 using CallbackReturnT = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 CallbackReturnT
-LocalizerNode::on_configure(const rclcpp_lifecycle::State & state)
+LocalizerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   std::vector<std::string> localizer_types;
   declare_parameter("localizer_types", localizer_types);
   get_parameter("localizer_types", localizer_types);
@@ -116,39 +113,32 @@ LocalizerNode::on_configure(const rclcpp_lifecycle::State & state)
 }
 
 CallbackReturnT
-LocalizerNode::on_activate(const rclcpp_lifecycle::State & state)
+LocalizerNode::on_activate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-LocalizerNode::on_deactivate(const rclcpp_lifecycle::State & state)
+LocalizerNode::on_deactivate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-LocalizerNode::on_cleanup(const rclcpp_lifecycle::State & state)
+LocalizerNode::on_cleanup([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-LocalizerNode::on_shutdown(const rclcpp_lifecycle::State & state)
+LocalizerNode::on_shutdown([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-LocalizerNode::on_error(const rclcpp_lifecycle::State & state)
+LocalizerNode::on_error([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 

--- a/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
@@ -20,8 +20,6 @@
 /// \file
 /// \brief Implementation of the DummyMapsManager class.
 
-#include <expected>
-
 #include "easynav_maps_manager/DummyMapsManager.hpp"
 
 namespace easynav

--- a/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
@@ -20,16 +20,12 @@
 /// \file
 /// \brief Implementation of the MapsManagerNode class.
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "easynav_maps_manager/MapsManagerNode.hpp"
-#include "easynav_core/MapsManagerBase.hpp"
-#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -69,10 +65,8 @@ MapsManagerNode::~MapsManagerNode()
 using CallbackReturnT = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 CallbackReturnT
-MapsManagerNode::on_configure(const rclcpp_lifecycle::State & state)
+MapsManagerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   std::vector<std::string> map_types;
   declare_parameter("map_types", map_types);
   get_parameter("map_types", map_types);
@@ -115,39 +109,32 @@ MapsManagerNode::on_configure(const rclcpp_lifecycle::State & state)
 }
 
 CallbackReturnT
-MapsManagerNode::on_activate(const rclcpp_lifecycle::State & state)
+MapsManagerNode::on_activate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-MapsManagerNode::on_deactivate(const rclcpp_lifecycle::State & state)
+MapsManagerNode::on_deactivate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-MapsManagerNode::on_cleanup(const rclcpp_lifecycle::State & state)
+MapsManagerNode::on_cleanup([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-MapsManagerNode::on_shutdown(const rclcpp_lifecycle::State & state)
+MapsManagerNode::on_shutdown([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-MapsManagerNode::on_error(const rclcpp_lifecycle::State & state)
+MapsManagerNode::on_error([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -20,8 +20,6 @@
 /// \file
 /// \brief Implementation of the DummyPlanner class.
 
-#include <expected>
-
 #include "easynav_planner/DummyPlanner.hpp"
 
 namespace easynav

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -20,15 +20,12 @@
 /// \file
 /// \brief Implementation of the PlannerNode class.
 
-#include "nav_msgs/msg/path.hpp"
 #include "pluginlib/class_loader.hpp"
 
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "easynav_planner/PlannerNode.hpp"
-#include "easynav_core/PlannerMethodBase.hpp"
-#include "easynav_common/YTSession.hpp"
 
 namespace easynav
 {
@@ -67,10 +64,8 @@ PlannerNode::~PlannerNode()
 using CallbackReturnT = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 CallbackReturnT
-PlannerNode::on_configure(const rclcpp_lifecycle::State & state)
+PlannerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   std::vector<std::string> planner_types;
   declare_parameter("planner_types", planner_types);
   get_parameter("planner_types", planner_types);
@@ -117,39 +112,32 @@ PlannerNode::on_configure(const rclcpp_lifecycle::State & state)
 }
 
 CallbackReturnT
-PlannerNode::on_activate(const rclcpp_lifecycle::State & state)
+PlannerNode::on_activate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-PlannerNode::on_deactivate(const rclcpp_lifecycle::State & state)
+PlannerNode::on_deactivate([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
-
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-PlannerNode::on_cleanup(const rclcpp_lifecycle::State & state)
+PlannerNode::on_cleanup([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-PlannerNode::on_shutdown(const rclcpp_lifecycle::State & state)
+PlannerNode::on_shutdown([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 
 CallbackReturnT
-PlannerNode::on_error(const rclcpp_lifecycle::State & state)
+PlannerNode::on_error([[maybe_unused]] const rclcpp_lifecycle::State & state)
 {
-  (void)state;
   return CallbackReturnT::SUCCESS;
 }
 

--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -26,8 +26,6 @@
 #include <unordered_map>
 #include <array>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "lifecycle_msgs/msg/transition.hpp"

--- a/easynav_sensors/tests/sensors_node_tests.cpp
+++ b/easynav_sensors/tests/sensors_node_tests.cpp
@@ -19,7 +19,6 @@
 
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
-#include "easynav_common/types/Perceptions.hpp"
 #include "easynav_sensors/SensorsNode.hpp"
 #include "easynav_common/RTTFBuffer.hpp"
 #include "easynav_common/types/NavState.hpp"
@@ -30,11 +29,8 @@
 
 #include "pcl/point_types.h"
 #include "pcl_conversions/pcl_conversions.h"
-#include "pcl/point_types_conversion.h"
-#include "pcl/common/transforms.h"
 #include "tf2_ros/transform_broadcaster.hpp"
 #include "tf2_ros/transform_listener.hpp"
-#include "tf2/transform_datatypes.hpp"
 
 #include "gtest/gtest.h"
 

--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_SYSTEM__GOALMANAGER_HPP_
 #define EASYNAV_SYSTEM__GOALMANAGER_HPP_
 
-#include <expected>
-
 #include "rclcpp/subscription.hpp"
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/macros.hpp"

--- a/easynav_system/include/easynav_system/GoalManagerClient.hpp
+++ b/easynav_system/include/easynav_system/GoalManagerClient.hpp
@@ -24,7 +24,6 @@
 #define EASYNAV_SYSTEM__GOALMANAGERCLIENT_HPP_
 
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "easynav_interfaces/msg/navigation_control.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -23,9 +23,10 @@
 #include <numbers>
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2/utils.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+
 #include "easynav_system/GoalManager.hpp"
 
-#include "nav_msgs/msg/odometry.hpp"
 
 namespace easynav
 {

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -23,8 +23,6 @@
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
-#include "easynav_system/SystemNode.hpp"
-
 #include "easynav_controller/ControllerNode.hpp"
 #include "easynav_localizer/LocalizerNode.hpp"
 #include "easynav_maps_manager/MapsManagerNode.hpp"
@@ -33,10 +31,7 @@
 #include "easynav_common/YTSession.hpp"
 #include "easynav_common/types/PointPerception.hpp"
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/macros.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
-
+#include "easynav_system/SystemNode.hpp"
 
 namespace easynav
 {

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -27,7 +27,7 @@
 
 #include "easynav_system/SystemNode.hpp"
 #include "easynav_common/RTTFBuffer.hpp"
-#include <easynav_common/YTSession.hpp>
+#include "easynav_common/YTSession.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"


### PR DESCRIPTION
Good evening,

This PR aims to reduce the amount of included headers that are not being used.

Sometimes they are not used at all, some other times they can be moved down in the dependency tree (e.g. include the dependency header in `MyClass.cpp` instead of `MyClass.hpp`).

Why? First, to reduce the amount of warnings given by linters and static analysis tools. Second (and most important), to try to reduce the very long compile times we have. After the cleanup changes in the three main repos, the time compiling my workspace was reduced from 3min 20s to 2min 50s. It ain't much, but it's honest work.

I will open PRs with the same changes in navmap and easynav_plugins.

Have a nice weekend, and think about the environmental footprint of wasted compile time.
