### PR TITLE
Downgrade from C++23 features

### DIFF
--- a/easynav_common/tests/perceptions_tests.cpp
+++ b/easynav_common/tests/perceptions_tests.cpp
@@ -75,7 +75,7 @@ public:
   }
 
   // Debug helper: print buffer contents and current visible state
-  void debug_print_buffer(const std::string & header)
+  void debug_print_buffer([[maybe_unused]] const std::string & header)
   {
     // std::cerr << "-----------------------------\n";
     // std::cerr << "DEBUG: " << header << "\n";
@@ -85,8 +85,8 @@ public:
     //          << " valid=" << std::boolalpha << valid
     //          << " new_data=" << new_data << "\n";
 
-    const std::size_t cap = buffer.capacity();
     const std::size_t sz = buffer.size();
+    // const std::size_t cap = buffer.capacity();
     // std::cerr << "Buffer state: size=" << sz
     //          << " capacity=" << cap << "\n";
 

--- a/easynav_controller/include/easynav_controller/DummyController.hpp
+++ b/easynav_controller/include/easynav_controller/DummyController.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_CONTROLLER__DUMMYCONTROLLER_HPP_
 #define EASYNAV_CONTROLLER__DUMMYCONTROLLER_HPP_
 
-#include <expected>
-
 #include "geometry_msgs/msg/twist_stamped.hpp"
 
 #include "easynav_core/ControllerMethodBase.hpp"
@@ -50,12 +48,8 @@ public:
    *
    * This method is called once during the configuration phase of the controller node,
    * and can be optionally overridden by derived classes to perform custom setup logic.
-   *
-   * @return std::expected<void, std::string> Returns an expected object:
-   *         - `void` if initialization was successful,
-   *         - a `std::string` containing an error message if initialization failed.
    */
-  virtual std::expected<void, std::string> on_initialize() override;
+  virtual void on_initialize() override;
 
   /**
    * @brief Run the control method and update the control command.

--- a/easynav_controller/src/easynav_controller/ControllerNode.cpp
+++ b/easynav_controller/src/easynav_controller/ControllerNode.cpp
@@ -102,11 +102,11 @@ ControllerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & st
 
       controller_method_ = controller_loader_->createSharedInstance(plugin);
 
-      auto result = controller_method_->initialize(shared_from_this(), controller_type);
-
-      if (!result) {
+      try {
+        controller_method_->initialize(shared_from_this(), controller_type);
+      } catch (const std::runtime_error & e) {
         RCLCPP_ERROR(get_logger(),
-          "Unable to initialize [%s]. Error: %s", plugin.c_str(), result.error().c_str());
+          "Unable to initialize [%s]. Error: %s", plugin.c_str(), e.what());
         return CallbackReturnT::FAILURE;
       }
 

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -29,15 +29,13 @@
 namespace easynav
 {
 
-std::expected<void, std::string> DummyController::on_initialize()
+void DummyController::on_initialize()
 {
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
   node->declare_parameter<double>(plugin_name + ".cycle_time_rt", 0.0);
   node->get_parameter<double>(plugin_name + ".cycle_time_rt", cycle_time_rt_);
-
-  return {};
 }
 
 void DummyController::update_rt([[maybe_unused]] NavState & nav_state)

--- a/easynav_core/include/easynav_core/ControllerMethodBase.hpp
+++ b/easynav_core/include/easynav_core/ControllerMethodBase.hpp
@@ -59,10 +59,9 @@ public:
    * @param parent_node Reference to the parent lifecycle node.
    * @param plugin_name Plugin identifier used for namespacing parameters.
    * @param tf_prefix Optional TF prefix for frame resolution.
-   * @return An empty value on success, or an error message otherwise.
+   * @throws std::runtime_error on initialization failure.
    */
-  virtual std::expected<void, std::string>
-  initialize(
+  virtual void initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
     const std::string & plugin_name);
 

--- a/easynav_core/include/easynav_core/MethodBase.hpp
+++ b/easynav_core/include/easynav_core/MethodBase.hpp
@@ -24,7 +24,6 @@
 #define EASYNAV_CORE__METHODBASE_HPP_
 
 #include <memory>
-#include <expected>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -54,10 +53,9 @@ public:
    *
    * @param parent_node Shared pointer to the parent lifecycle node.
    * @param plugin_name Name of the plugin (used for parameters and logging).
-   * @return std::expected<void, std::string> indicating success or failure.
+   * @throws std::runtime_error on initialization failure.
    */
-  virtual std::expected<void, std::string>
-  initialize(
+  virtual void initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
     const std::string & plugin_name);
 
@@ -65,10 +63,9 @@ public:
    * @brief Hook for custom setup logic in derived classes.
    *
    * Called from initialize(). Can be overridden to implement extra initialization steps.
-   *
-   * @return std::expected<void, std::string> indicating success or failure.
+   * @throws std::runtime_error on initialization failure.
    */
-  virtual std::expected<void, std::string> on_initialize() {return {};}
+  virtual void on_initialize() {}
 
   /**
    * @brief Get a shared pointer to the parent lifecycle node.

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -35,7 +35,7 @@
 namespace easynav
 {
 
-std::expected<void, std::string>
+void
 ControllerMethodBase::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
   const std::string & plugin_name)
@@ -63,7 +63,7 @@ ControllerMethodBase::initialize(
   node->get_parameter("colision_checker.z_min_filter", z_min_filter_);
   node->get_parameter("colision_checker.downsample_leaf_size", downsample_leaf_size_);
 
-  return MethodBase::initialize(parent_node, plugin_name);
+  MethodBase::initialize(parent_node, plugin_name);
 }
 
 bool

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -21,7 +21,6 @@
 /// \brief Implementation of the base class MethodBase used in plugin-based EasyNav method components.
 
 #include <memory>
-#include <expected>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -30,7 +29,7 @@
 namespace easynav
 {
 
-std::expected<void, std::string>
+void
 MethodBase::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
   const std::string & plugin_name)
@@ -49,7 +48,7 @@ MethodBase::initialize(
   last_ts_ = parent_node_->now();
   rt_last_ts_ = parent_node_->now();
 
-  return on_initialize();
+  on_initialize();
 }
 
 std::shared_ptr<rclcpp_lifecycle::LifecycleNode>

--- a/easynav_core/test/core_method_test.cpp
+++ b/easynav_core/test/core_method_test.cpp
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #include "gtest/gtest.h"
-#include <expected>
 
 #include "nav_msgs/msg/odometry.hpp"
 
@@ -48,10 +47,9 @@ public:
   MockMethod() = default;
   ~MockMethod() = default;
 
-  std::expected<void, std::string> on_initialize() override
+  void on_initialize() override
   {
     on_initialize_called_ = true;
-    return {};
   }
 
 public:
@@ -65,11 +63,10 @@ public:
   TestLocalizer() = default;
   ~TestLocalizer() = default;
 
-  std::expected<void, std::string> on_initialize() override
+  void on_initialize() override
   {
     odom_.header.frame_id = easynav::RTTFBuffer::getInstance()->get_tf_info().robot_frame;
     odom_.pose.pose.position.x = 5;
-    return {};
   }
 
   virtual void update_rt(easynav::NavState & nav_state) override
@@ -121,10 +118,9 @@ TEST_F(CoreMethodTestCase, TFInfoPropagatesToDerived)
   class TFInfoProbeMethod : public easynav::MethodBase
   {
 public:
-    std::expected<void, std::string> on_initialize() override
+    void on_initialize() override
     {
       seen_tf_info = easynav::RTTFBuffer::getInstance()->get_tf_info();
-      return {};
     }
 
     easynav::TFInfo seen_tf_info;

--- a/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
+++ b/easynav_localizer/include/easynav_localizer/DummyLocalizer.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_LOCALIZER__DUMMYLOCALIZER_HPP_
 #define EASYNAV_LOCALIZER__DUMMYLOCALIZER_HPP_
 
-#include <expected>
-
 #include "nav_msgs/msg/odometry.hpp"
 #include "easynav_core/LocalizerMethodBase.hpp"
 #include "tf2_ros/transform_broadcaster.hpp"
@@ -50,10 +48,8 @@ public:
 
   /**
    * @brief Plugin-specific initialization logic.
-   *
-   * @return Success or an error message.
    */
-  virtual std::expected<void, std::string> on_initialize() override;
+  virtual void on_initialize() override;
 
   /**
    * @brief Update the localization using the current navigation state.

--- a/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
+++ b/easynav_localizer/src/easynav_localizer/DummyLocalizer.cpp
@@ -27,7 +27,7 @@
 namespace easynav
 {
 
-std::expected<void, std::string> DummyLocalizer::on_initialize()
+void DummyLocalizer::on_initialize()
 {
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
@@ -38,8 +38,6 @@ std::expected<void, std::string> DummyLocalizer::on_initialize()
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
 
   tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(get_node());
-
-  return {};
 }
 
 void DummyLocalizer::update_rt([[maybe_unused]] NavState & nav_state)

--- a/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
+++ b/easynav_localizer/src/easynav_localizer/LocalizerNode.cpp
@@ -88,11 +88,11 @@ LocalizerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & sta
 
       localizer_method_ = localizer_loader_->createSharedInstance(plugin);
 
-      auto result = localizer_method_->initialize(shared_from_this(), localizer_type);
-
-      if (!result) {
+      try {
+        localizer_method_->initialize(shared_from_this(), localizer_type);
+      } catch (const std::runtime_error & e) {
         RCLCPP_ERROR(get_logger(),
-          "Unable to initialize [%s]. Error: %s", plugin.c_str(), result.error().c_str());
+          "Unable to initialize [%s]. Error: %s", plugin.c_str(), e.what());
         return CallbackReturnT::FAILURE;
       }
 

--- a/easynav_maps_manager/include/easynav_maps_manager/DummyMapsManager.hpp
+++ b/easynav_maps_manager/include/easynav_maps_manager/DummyMapsManager.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_PLANNER__DUMMYMAPMANAGER_HPP_
 #define EASYNAV_PLANNER__DUMMYMAPMANAGER_HPP_
 
-#include <expected>
-
 #include "easynav_core/MapsManagerBase.hpp"
 
 namespace easynav
@@ -47,9 +45,8 @@ public:
 
   /**
    * @brief Initialize the plugin.
-   * @return Success or error message.
    */
-  virtual std::expected<void, std::string> on_initialize() override;
+  virtual void on_initialize() override;
 
   /**
    * @brief Dummy update method.

--- a/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/DummyMapsManager.cpp
@@ -25,15 +25,13 @@
 namespace easynav
 {
 
-std::expected<void, std::string> DummyMapsManager::on_initialize()
+void DummyMapsManager::on_initialize()
 {
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
   node->declare_parameter<double>(plugin_name + ".cycle_time_nort", 0.0);
   node->get_parameter<double>(plugin_name + ".cycle_time_nort", cycle_time_nort_);
-
-  return {};
 }
 
 void

--- a/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
+++ b/easynav_maps_manager/src/easynav_maps_manager/MapsManagerNode.cpp
@@ -83,11 +83,11 @@ MapsManagerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & s
       std::shared_ptr<MapsManagerBase> instance;
       instance = maps_manager_loader_->createSharedInstance(plugin);
 
-      auto result = instance->initialize(shared_from_this(), map_type);
-
-      if (!result) {
+      try {
+        instance->initialize(shared_from_this(), map_type);
+      } catch (const std::runtime_error & e) {
         RCLCPP_ERROR(get_logger(),
-          "Unable to initialize [%s]. Error: %s", plugin.c_str(), result.error().c_str());
+          "Unable to initialize [%s]. Error: %s", plugin.c_str(), e.what());
         return CallbackReturnT::FAILURE;
       }
 

--- a/easynav_planner/include/easynav_planner/DummyPlanner.hpp
+++ b/easynav_planner/include/easynav_planner/DummyPlanner.hpp
@@ -23,8 +23,6 @@
 #ifndef EASYNAV_PLANNER__DUMMYPLANNER_HPP_
 #define EASYNAV_PLANNER__DUMMYPLANNER_HPP_
 
-#include <expected>
-
 #include "nav_msgs/msg/path.hpp"
 #include "easynav_core/PlannerMethodBase.hpp"
 
@@ -48,9 +46,8 @@ public:
 
   /**
    * @brief Initialization hook.
-   * @return Success or error message.
    */
-  virtual std::expected<void, std::string> on_initialize() override;
+  virtual void on_initialize() override;
 
   /**
    * @brief Dummy update method.

--- a/easynav_planner/src/easynav_planner/DummyPlanner.cpp
+++ b/easynav_planner/src/easynav_planner/DummyPlanner.cpp
@@ -26,7 +26,7 @@
 namespace easynav
 {
 
-std::expected<void, std::string> DummyPlanner::on_initialize()
+void DummyPlanner::on_initialize()
 {
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
@@ -38,8 +38,6 @@ std::expected<void, std::string> DummyPlanner::on_initialize()
   path_.header.stamp = get_node()->now();
   path_.header.frame_id = easynav::RTTFBuffer::getInstance()->get_tf_info().map_frame;
   path_.poses.clear();
-
-  return {};
 }
 
 void DummyPlanner::update([[maybe_unused]] NavState & nav_state)

--- a/easynav_planner/src/easynav_planner/PlannerNode.cpp
+++ b/easynav_planner/src/easynav_planner/PlannerNode.cpp
@@ -87,11 +87,11 @@ PlannerNode::on_configure([[maybe_unused]] const rclcpp_lifecycle::State & state
 
       planner_method_ = planner_loader_->createSharedInstance(plugin);
 
-      auto result = planner_method_->initialize(shared_from_this(), planner_type);
-
-      if (!result) {
+      try {
+        planner_method_->initialize(shared_from_this(), planner_type);
+      } catch (const std::runtime_error & e) {
         RCLCPP_ERROR(get_logger(),
-          "Unable to initialize [%s]. Error: %s", plugin.c_str(), result.error().c_str());
+          "Unable to initialize [%s]. Error: %s", plugin.c_str(), e.what());
         return CallbackReturnT::FAILURE;
       }
 


### PR DESCRIPTION
Dear all,

Thanks to the buildfarm failure in RHEL9 packages, I realized that C++23 features are not supported on some target platforms. In fact, the officially supported C++ version is still C++17 in [kilted](https://docs.ros.org/en/kilted/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html#id2).

For this reason, I think we should remove those features, so we can continue with the initial release process. So far, the only "problem" I have found is the use of `std::expected` in the `MethodBase::initialize` interface, which is removed in this PR.

Instead, if a plugin has any problem during initialization, it should throw a `std::runtime_error`.

**Note 1:** If there is any other C++20/C++23 feature I miss, please let me know to downgrade it.
**Note 2:** I will send another PR to easynav_plugins to update to the new `MethodBase` interface.

I am open to any other suggestions or approaches.

Best,
Fran.