### PR TITLE
Hotfix: Remove remaining C++20/23 features

### DIFF
--- a/easynav_common/CMakeLists.txt
+++ b/easynav_common/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 option(EASYNAV_TRACING "Enable Yaets tracing with TRACE_EVENT" ON)
 
 find_package(ament_cmake REQUIRED)

--- a/easynav_controller/CMakeLists.txt
+++ b/easynav_controller/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/easynav_controller/src/easynav_controller/DummyController.cpp
+++ b/easynav_controller/src/easynav_controller/DummyController.cpp
@@ -20,8 +20,6 @@
 /// \file
 /// \brief Implementation of the DummyController class.
 
-#include <expected>
-
 #include "easynav_controller/DummyController.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "easynav_common/RTTFBuffer.hpp"

--- a/easynav_core/CMakeLists.txt
+++ b/easynav_core/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(easynav_common REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/easynav_interfaces/CMakeLists.txt
+++ b/easynav_interfaces/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)

--- a/easynav_localizer/CMakeLists.txt
+++ b/easynav_localizer/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/easynav_maps_manager/CMakeLists.txt
+++ b/easynav_maps_manager/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/easynav_planner/CMakeLists.txt
+++ b/easynav_planner/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/easynav_sensors/CMakeLists.txt
+++ b/easynav_sensors/CMakeLists.txt
@@ -7,10 +7,6 @@ endif()
 
 set(CMAKE_BUILD_TYPE DEBUG)
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/easynav_system/CMakeLists.txt
+++ b/easynav_system/CMakeLists.txt
@@ -5,10 +5,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -20,7 +20,7 @@
 /// \file
 /// \brief Implementation of the GoalManager class.
 
-#include <numbers>
+#include <cmath>
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2/utils.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -50,12 +50,11 @@ double calculate_distance_xy(
 /** Angle normalization to [-pi, pi) range (in radians) */
 constexpr double norm_angle(const double angle)
 {
-  using std::numbers::pi;
-  double out_angle = std::fmod(angle + pi, 2 * pi);
+  double out_angle = std::fmod(angle + M_PI, 2 * M_PI);
   if (out_angle < 0.0) {
-    out_angle += 2 * pi;
+    out_angle += 2 * M_PI;
   }
-  return out_angle - pi;
+  return out_angle - M_PI;
 }
 
 /**


### PR DESCRIPTION
Hotfix related to https://github.com/EasyNavigation/EasyNavigation/pull/82:

* There was an unexpected `<expected>`.
* `std::numbers::pi` is C++20.
* I also removed the `(CMAKE_CXX_STANDARD 23)` variables from CMake so we get errors whenever we use modern features.