### PR TITLE
Update CI to use container workers

### DIFF
--- a/.github/workflows/humble.yaml
+++ b/.github/workflows/humble.yaml
@@ -9,19 +9,15 @@ on:
       - humble
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-      fail-fast: false
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:jammy
     steps:
       - uses: actions/checkout@v4
         with:
           ref: humble
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: humble
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/humble_cron.yaml
+++ b/.github/workflows/humble_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-      fail-fast: false
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:jammy
     steps:
       - uses: actions/checkout@v4
         with:
           ref: humble
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: humble
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/jazzy.yaml
+++ b/.github/workflows/jazzy.yaml
@@ -9,19 +9,15 @@ on:
       - jazzy
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: jazzy
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: jazzy
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/jazzy_cron.yaml
+++ b/.github/workflows/jazzy_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: jazzy
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: jazzy
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/kilted.yaml
+++ b/.github/workflows/kilted.yaml
@@ -9,19 +9,15 @@ on:
       - kilted
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: kilted
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: kilted
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/kilted_cron.yaml
+++ b/.github/workflows/kilted_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: kilted
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: kilted
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -9,19 +9,15 @@ on:
       - rolling
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: rolling
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: rolling
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/rolling_cron.yaml
+++ b/.github/workflows/rolling_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: rolling
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: rolling
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:


### PR DESCRIPTION
Hi,

Lately the CI have been failing in all of our repos with very random causes like not being able to find ament_cmake or the messages that were just built.

There seems to be an issue with `apt-get` in bare metal GitHub actions workers when using the [setup-ros action](https://github.com/ros-tooling/setup-ros#overview). I am not sure 100% this is the issue, but after changing the CI worker to a container it seems to work.

If the issue gets fixed I will manually port it to the other distro branches.

P.S.: I also removed the matrix configuration because there is only one OS variant (ubuntu).