### PR TITLE
Fix bug when using multiple sensors

### DIFF
--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -213,7 +213,8 @@ SensorsNode::cycle_rt(
   bool trigger_perceptions = false;
   // Run handlers' cycle and check if there is new sensor data o trigger perceptions
   for (auto & handler : handler_list_) {
-    trigger_perceptions = trigger_perceptions || handler->cycle_rt(nav_state);
+    const bool trigger = handler->cycle_rt(nav_state);
+    trigger_perceptions = trigger_perceptions || trigger;
   }
 
   return trigger_perceptions;


### PR DESCRIPTION
When using multiple sensors, if the first handler's `cycle_rt` returns true (there is a trigger), then the cycle of the remainder handlers may not be executed, because the trigger flag was already set.