### PR TITLE
Limit GoalManager publication freq

### DIFF
--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -162,16 +162,16 @@ private:
   /// @brief Timestamp when the current navigation started.
   rclcpp::Time nav_start_time_;
 
-  /// @brief Maximum frequency (Hz) at which update() actually runs.
+  /// @brief Maximum frequency (Hz) at which FEEDBACK / GoalManagerInfo is published.
   double update_frequency_ {20.0};
 
-  /// @brief Minimum period between consecutive update() executions.
+  /// @brief Minimum period between consecutive FEEDBACK / GoalManagerInfo publications.
   rclcpp::Duration update_period_ {0, 0};
 
-  /// @brief Timestamp of the last executed update().
+  /// @brief Timestamp of the last FEEDBACK / GoalManagerInfo publication.
   rclcpp::Time last_update_time_;
 
-  /// @brief Whether update() has run at least once.
+  /// @brief Whether feedback/info has been published at least once.
   bool first_update_ {true};
 
   /// @brief Handle new goal request and populate the response.

--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -162,6 +162,18 @@ private:
   /// @brief Timestamp when the current navigation started.
   rclcpp::Time nav_start_time_;
 
+  /// @brief Maximum frequency (Hz) at which update() actually runs.
+  double update_frequency_ {20.0};
+
+  /// @brief Minimum period between consecutive update() executions.
+  rclcpp::Duration update_period_ {0, 0};
+
+  /// @brief Timestamp of the last executed update().
+  rclcpp::Time last_update_time_;
+
+  /// @brief Whether update() has run at least once.
+  bool first_update_ {true};
+
   /// @brief Handle new goal request and populate the response.
   void accept_request(
     const easynav_interfaces::msg::NavigationControl & msg,

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -79,10 +79,14 @@ GoalManager::GoalManager(
   parent_node_->declare_parameter("position_tolerance", goal_tolerance_.position);
   parent_node_->declare_parameter("height_tolerance", goal_tolerance_.height);
   parent_node_->declare_parameter("angle_tolerance", goal_tolerance_.yaw);
+  parent_node_->declare_parameter("update_frequency", update_frequency_);
   parent_node_->get_parameter("allow_preempt_goal", allow_preempt_goal_);
   parent_node_->get_parameter("position_tolerance", goal_tolerance_.position);
   parent_node_->get_parameter("height_tolerance", goal_tolerance_.height);
   parent_node_->get_parameter("angle_tolerance", goal_tolerance_.yaw);
+  parent_node_->get_parameter("update_frequency", update_frequency_);
+
+  update_period_ = rclcpp::Duration::from_seconds(1.0 / update_frequency_);
 
   // Expose initial goal tolerances in NavState so controllers can reuse them
   nav_state.set("goal_tolerance.position", goal_tolerance_.position);
@@ -344,15 +348,28 @@ GoalManager::update(NavState & nav_state)
   feedback.current_pose.pose = odom.pose.pose;
   feedback.navigation_time = parent_node_->now() - nav_start_time_;
 
-  const auto & first_goal = goals_.goals.front().pose;
+  // Copy (not reference): check_goals() below may erase the front goal, which would
+  // otherwise leave this dangling.
+  const auto first_goal = goals_.goals.front().pose;
   feedback.distance_to_goal = calculate_distance_xy(robot_pose, first_goal);
 
   // ToDo[@fmrico]: Complete feedback info: estimated_time_remaining and distance_covered
 
-  RCLCPP_DEBUG(parent_node_->get_logger(), "Sending navigation feedback");
+  // Throttle only the periodic FEEDBACK / GoalManagerInfo publishing so these topics
+  // aren't saturated. The nav_state bookkeeping below (goals, navigation_state) must run
+  // every cycle regardless, since the planner reacts to it as soon as a new goal's
+  // timestamp is newer than its last planned one (see SystemNode::system_cycle()); delaying
+  // that sync here would make the planner compute a path from stale/empty goals.
+  const auto now = parent_node_->now();
+  const bool should_publish = first_update_ || (now - last_update_time_) >= update_period_;
 
-  control_pub_->publish(feedback);
-  *last_control_ = feedback;
+  if (should_publish) {
+    RCLCPP_DEBUG(parent_node_->get_logger(), "Sending navigation feedback");
+    control_pub_->publish(feedback);
+    *last_control_ = feedback;
+    first_update_ = false;
+    last_update_time_ = now;
+  }
 
   check_goals(robot_pose, goal_tolerance_);
 
@@ -374,7 +391,7 @@ GoalManager::update(NavState & nav_state)
     nav_state.set("navigation_state", state_);
   }
 
-  if (info_pub_->get_subscription_count() > 0) {
+  if (should_publish && info_pub_->get_subscription_count() > 0) {
     easynav_interfaces::msg::GoalManagerInfo msg;
     msg.status = static_cast<int>(get_state());
     msg.goals = get_goals();

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -85,9 +85,15 @@ GoalManager::GoalManager(
   parent_node_->get_parameter("height_tolerance", goal_tolerance_.height);
   parent_node_->get_parameter("angle_tolerance", goal_tolerance_.yaw);
   parent_node_->get_parameter("update_frequency", update_frequency_);
+  if (update_frequency_ <= 0.0) {
+    RCLCPP_WARN(
+      parent_node_->get_logger(),
+      "Parameter 'update_frequency' must be > 0.0 (got %.3f); falling back to 20.0",
+      update_frequency_);
+    update_frequency_ = 20.0;
+  }
 
   update_period_ = rclcpp::Duration::from_seconds(1.0 / update_frequency_);
-
   // Expose initial goal tolerances in NavState so controllers can reuse them
   nav_state.set("goal_tolerance.position", goal_tolerance_.position);
   nav_state.set("goal_tolerance.height", goal_tolerance_.height);

--- a/easynav_system/tests/goalmanager_tests.cpp
+++ b/easynav_system/tests/goalmanager_tests.cpp
@@ -1396,8 +1396,8 @@ TEST_F(GoalManagerTestCase, update_respects_frequency_limit)
 
   // Warm-up: get GoalManager into ACTIVE state.
   rclcpp::Rate warmup_rate(test_frequency);
-  auto start = client_node->now();
-  while (client_node->now() - start < 500ms) {
+  auto start = system_node->now();
+  while (system_node->now() - start < 500ms) {
     gm_server->update(*nav_state);
     exe.spin_some();
     warmup_rate.sleep();

--- a/easynav_system/tests/goalmanager_tests.cpp
+++ b/easynav_system/tests/goalmanager_tests.cpp
@@ -1389,7 +1389,7 @@ TEST_F(GoalManagerTestCase, update_respects_frequency_limit)
 
   geometry_msgs::msg::PoseStamped goal;
   goal.header.frame_id = "map";
-  goal.header.stamp = client_node->now();
+  goal.header.stamp = system_node->now();
   goal.pose.position.x = 1000.0;  // Far enough to never be reached during the test.
 
   pose_pub->publish(goal);

--- a/easynav_system/tests/goalmanager_tests.cpp
+++ b/easynav_system/tests/goalmanager_tests.cpp
@@ -1409,8 +1409,8 @@ TEST_F(GoalManagerTestCase, update_respects_frequency_limit)
   // should actually go through and publish feedback.
   feedback_count = 0;
   const auto window = 600ms;
-  start = client_node->now();
-  while (client_node->now() - start < window) {
+  start = system_node->now();
+  while (system_node->now() - start < window) {
     gm_server->update(*nav_state);
     exe.spin_some();
   }

--- a/easynav_system/tests/goalmanager_tests.cpp
+++ b/easynav_system/tests/goalmanager_tests.cpp
@@ -1342,3 +1342,81 @@ TEST_F(GoalManagerTestCase, two_clients)
   ASSERT_EQ(gm_client1->get_state(), easynav::GoalManagerClient::State::IDLE);
   ASSERT_EQ(gm_client2->get_state(), easynav::GoalManagerClient::State::IDLE);
 }
+
+TEST_F(GoalManagerTestCase, default_update_frequency)
+{
+  auto nav_state = std::make_shared<easynav::NavState>();
+  auto system_node = rclcpp_lifecycle::LifecycleNode::make_shared("system_node");
+
+  auto gm_server = easynav::GoalManager::make_shared(*nav_state, system_node);
+
+  double freq = 0.0;
+  ASSERT_TRUE(system_node->get_parameter("update_frequency", freq));
+  ASSERT_DOUBLE_EQ(freq, 20.0);
+}
+
+TEST_F(GoalManagerTestCase, update_respects_frequency_limit)
+{
+  auto nav_state = std::make_shared<easynav::NavState>();
+  nav_state->set("robot_pose", nav_msgs::msg::Odometry());
+
+  auto client_node = rclcpp::Node::make_shared("client_node");
+
+  // Use a non-default frequency to prove the parameter actually drives the gating.
+  const double test_frequency = 10.0;
+  auto system_node = rclcpp_lifecycle::LifecycleNode::make_shared(
+    "system_node",
+    rclcpp::NodeOptions().parameter_overrides(
+      {rclcpp::Parameter("update_frequency", test_frequency)}));
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(client_node);
+  exe.add_node(system_node->get_node_base_interface());
+
+  int feedback_count = 0;
+  auto control_sub = client_node->create_subscription<easynav_interfaces::msg::NavigationControl>(
+    "easynav_control", 100,
+    [&feedback_count](easynav_interfaces::msg::NavigationControl::UniquePtr msg) {
+      if (msg->type == easynav_interfaces::msg::NavigationControl::FEEDBACK) {
+        feedback_count++;
+      }
+    });
+
+  auto pose_pub = client_node->create_publisher<geometry_msgs::msg::PoseStamped>(
+    "goal_pose", 100);
+
+  auto gm_server = easynav::GoalManager::make_shared(*nav_state, system_node);
+
+  geometry_msgs::msg::PoseStamped goal;
+  goal.header.frame_id = "map";
+  goal.header.stamp = client_node->now();
+  goal.pose.position.x = 1000.0;  // Far enough to never be reached during the test.
+
+  pose_pub->publish(goal);
+
+  // Warm-up: get GoalManager into ACTIVE state.
+  rclcpp::Rate warmup_rate(test_frequency);
+  auto start = client_node->now();
+  while (client_node->now() - start < 500ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    warmup_rate.sleep();
+  }
+
+  ASSERT_EQ(gm_server->get_state(), easynav::GoalManager::State::ACTIVE);
+
+  // Hammer update() as fast as possible; only test_frequency executions per second
+  // should actually go through and publish feedback.
+  feedback_count = 0;
+  const auto window = 600ms;
+  start = client_node->now();
+  while (client_node->now() - start < window) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+  }
+
+  const int expected = static_cast<int>(
+    test_frequency * std::chrono::duration<double>(window).count());
+  ASSERT_GE(feedback_count, expected - 2);
+  ASSERT_LE(feedback_count, expected + 2);
+}


### PR DESCRIPTION
Hi,

GoalManager is currently publishing feedback and control messages at high frequency (>=200Hz). This can cause problems, so in this PR this frequency is limited and set by parameter.

I hope it helps!!