### PR TITLE
Initialize transform

### DIFF
--- a/easynav_sensors/src/easynav_sensors/types/PointPerception.cpp
+++ b/easynav_sensors/src/easynav_sensors/types/PointPerception.cpp
@@ -787,7 +787,7 @@ PointPerceptionsOpsView::add(
   idx.resize(points.size());
   std::iota(idx.begin(), idx.end(), 0);
 
-  tf_transforms_.push_back(tf2::Transform());
+  tf_transforms_.push_back(tf2::Transform::getIdentity());
   tf_valid_.push_back(false);
 
   return *this;


### PR DESCRIPTION
Hi,

Related to https://github.com/EasyNavigation/easynav_plugins/pull/76, I have been removing warnings:

I hope it helps!!

### Warning cleanup

- **`easynav_sensors/.../types/PointPerception.cpp`**: replaced a default-constructed `tf2::Transform()` placeholder (Bullet-derived type, leaves members uninitialized by design) with `tf2::Transform::getIdentity()`, removing a `-Wmaybe-uninitialized` chain reported through inlined tf2/STL code.