### PR TITLE
Add get_safe method to NavState

### DIFF
--- a/easynav_common/include/easynav_common/types/NavState.hpp
+++ b/easynav_common/include/easynav_common/types/NavState.hpp
@@ -205,6 +205,46 @@ public:
     return *ptr;
   }
 
+  /// \brief Retrieves a snapshot copy of the stored value of type \p T for \p key.
+  ///
+  /// Unlike \ref get(), which returns a reference to the object owned by the internal
+  /// \c std::shared_ptr<T> (only valid for as long as no other thread calls \ref set() on the
+  /// same key), this makes the copy of \p T while \ref state_mutex_ is still held, so the
+  /// returned value is a stable, independent snapshot regardless of concurrent writers.
+  ///
+  /// Use this instead of \ref get() whenever the key can be written from a different thread
+  /// than the one calling this method (for example, values crossing the RT / non-RT boundary,
+  /// such as "path", "goals", "robot_pose" or "navigation_state"). Prefer \ref get() when the
+  /// writer and reader are known to run on the same thread (for example, most maps stored by a
+  /// maps manager and consumed by a localizer/planner on the non-RT cycle) to avoid paying an
+  /// unnecessary copy for potentially large values.
+  ///
+  /// \tparam T Expected stored type.
+  /// \param key Key to retrieve.
+  /// \return An independent copy of the stored \p T.
+  /// \throws std::runtime_error If \p key is missing or the stored type does not match \p T.
+  template<typename T>
+  T get_safe(const std::string & key) const
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    auto it = values_.find(key);
+
+    if (it == values_.end()) {
+      throw std::runtime_error("Key not found in get_safe: " + key);
+    }
+
+    if (types_.at(key) != typeid(T).hash_code()) {
+      std::ostringstream oss;
+      oss << "Type mismatch in get_safe(\"" << key << "\")\n"
+          << "  stored type   : " << type_names_.at(key) << "\n"
+          << "  requested type: " << demangle(typeid(T).name());
+      throw std::runtime_error(oss.str());
+    }
+
+    auto ptr = std::static_pointer_cast<T>(it->second);
+    return *ptr;  // copy made while state_mutex_ is still held
+  }
+
   /// \brief Retrieves the shared_ptr to the stored value of type \p T for \p key.
   ///
   /// The pointer refers to the object managed by the internal \c std::shared_ptr<T>.

--- a/easynav_common/tests/navstate_tests.cpp
+++ b/easynav_common/tests/navstate_tests.cpp
@@ -511,3 +511,210 @@ TEST_F(NavStateTest, GetNoGroupExcludesGroupedButNotUngroupedSameType)
   ASSERT_EQ(result.size(), 1u);
   EXPECT_DOUBLE_EQ(result[0]->position.x, 2.0);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// get_safe<T>()
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_F(NavStateTest, GetSafeReturnsStoredValuePrimitive)
+{
+  easynav::NavState state;
+  state.set("count", 42);
+  state.set("ratio", 3.5);
+  EXPECT_EQ(state.get_safe<int>("count"), 42);
+  EXPECT_DOUBLE_EQ(state.get_safe<double>("ratio"), 3.5);
+}
+
+TEST_F(NavStateTest, GetSafeReturnsStoredValueComplex)
+{
+  easynav::NavState state;
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 1.0;
+  pose.position.y = 2.0;
+  pose.position.z = 3.0;
+  pose.orientation.w = 1.0;
+  state.set("pose", pose);
+
+  geometry_msgs::msg::Pose copy = state.get_safe<geometry_msgs::msg::Pose>("pose");
+  EXPECT_DOUBLE_EQ(copy.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(copy.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(copy.position.z, 3.0);
+  EXPECT_DOUBLE_EQ(copy.orientation.w, 1.0);
+}
+
+TEST_F(NavStateTest, GetSafeMissingKeyThrows)
+{
+  easynav::NavState state;
+  EXPECT_THROW(state.get_safe<int>("missing"), std::runtime_error);
+}
+
+TEST_F(NavStateTest, GetSafeMissingKeyThrowsWithKeyInMessage)
+{
+  easynav::NavState state;
+  try {
+    state.get_safe<int>("missing_key_xyz");
+    FAIL() << "Expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    EXPECT_NE(std::string(e.what()).find("missing_key_xyz"), std::string::npos);
+  }
+}
+
+TEST_F(NavStateTest, GetSafeTypeMismatchThrows)
+{
+  easynav::NavState state;
+  state.set("value", std::string("hello"));
+  EXPECT_THROW(state.get_safe<int>("value"), std::runtime_error);
+}
+
+TEST_F(NavStateTest, GetSafeTypeMismatchThrowsWithTypeNamesInMessage)
+{
+  easynav::NavState state;
+  state.set("value", std::string("hello"));
+  try {
+    state.get_safe<int>("value");
+    FAIL() << "Expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("value"), std::string::npos);
+    EXPECT_NE(msg.find("Type mismatch"), std::string::npos);
+  }
+}
+
+TEST_F(NavStateTest, GetSafeDoesNotAliasInternalStorage)
+{
+  // Unlike get_ptr()/get(), get_safe() must hand back an object that is NOT
+  // the same instance as the one stored internally (it's a value copy).
+  easynav::NavState state;
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 1.0;
+  state.set("pose", pose);
+
+  auto internal_ptr = state.get_ptr<geometry_msgs::msg::Pose>("pose");
+  geometry_msgs::msg::Pose safe_copy = state.get_safe<geometry_msgs::msg::Pose>("pose");
+
+  EXPECT_NE(static_cast<const void *>(&safe_copy), static_cast<const void *>(internal_ptr.get()));
+}
+
+TEST_F(NavStateTest, GetSafeCopyIsUnaffectedByLaterSet)
+{
+  // The snapshot returned by get_safe() must not change when the key is
+  // overwritten afterwards (get<T>() would be unsafe here: set() mutates
+  // the referenced object in place).
+  easynav::NavState state;
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 1.0;
+  state.set("pose", pose);
+
+  geometry_msgs::msg::Pose snapshot = state.get_safe<geometry_msgs::msg::Pose>("pose");
+
+  geometry_msgs::msg::Pose updated;
+  updated.position.x = 999.0;
+  state.set("pose", updated);
+
+  EXPECT_DOUBLE_EQ(snapshot.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(state.get_safe<geometry_msgs::msg::Pose>("pose").position.x, 999.0);
+}
+
+TEST_F(NavStateTest, GetSafeMutatingReturnedCopyDoesNotAffectInternalState)
+{
+  easynav::NavState state;
+  state.set("count", 10);
+
+  int copy = state.get_safe<int>("count");
+  copy = 12345;
+
+  EXPECT_EQ(copy, 12345);
+  EXPECT_EQ(state.get_safe<int>("count"), 10);
+}
+
+TEST_F(NavStateTest, GetSafeWorksWithVectorType)
+{
+  easynav::NavState state;
+  std::vector<geometry_msgs::msg::Pose> poses(3);
+  poses[0].position.x = 0.0;
+  poses[1].position.x = 1.0;
+  poses[2].position.x = 2.0;
+  state.set("path", poses);
+
+  auto copy = state.get_safe<std::vector<geometry_msgs::msg::Pose>>("path");
+  ASSERT_EQ(copy.size(), 3u);
+  EXPECT_DOUBLE_EQ(copy[0].position.x, 0.0);
+  EXPECT_DOUBLE_EQ(copy[1].position.x, 1.0);
+  EXPECT_DOUBLE_EQ(copy[2].position.x, 2.0);
+
+  // Independent storage: the copied vector's buffer must not alias the
+  // internal one (this is the whole point of get_safe over get()).
+  auto internal_ptr = state.get_ptr<std::vector<geometry_msgs::msg::Pose>>("path");
+  EXPECT_NE(copy.data(), internal_ptr->data());
+}
+
+TEST_F(NavStateTest, GetSafeCoexistsWithPlainGet)
+{
+  // get_safe() must not disturb the entry for subsequent plain get() calls.
+  easynav::NavState state;
+  state.set("x", 7);
+  EXPECT_EQ(state.get_safe<int>("x"), 7);
+  EXPECT_EQ(state.get<int>("x"), 7);
+  state.set("x", 8);
+  EXPECT_EQ(state.get<int>("x"), 8);
+  EXPECT_EQ(state.get_safe<int>("x"), 8);
+}
+
+// Reproduces the exact hazard get_safe() is meant to close: a writer thread
+// repeatedly replacing a vector-valued key (forcing reallocation, as real
+// planners do with "path"/"goals") while a reader thread concurrently calls
+// get_safe<std::vector<T>>(). Because the copy is made while state_mutex_ is
+// held, every snapshot the reader observes must be a fully-formed vector of
+// consistent size/content — never a torn read, dangling pointer, or crash.
+TEST(NavStateStressTest, GetSafeConcurrentReadDuringReallocatingWrites)
+{
+  easynav::NavState state;
+  std::atomic<bool> start_flag{false};
+  std::atomic<bool> stop_flag{false};
+
+  std::vector<geometry_msgs::msg::Pose> initial(1);
+  state.set("path", initial);
+
+  auto writer = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      for (int i = 0; i < 5000 && !stop_flag.load(); ++i) {
+        // Varying size forces the internal std::vector to reallocate/free
+        // its buffer on (almost) every write.
+        std::vector<geometry_msgs::msg::Pose> path(1 + (i % 37));
+        for (size_t j = 0; j < path.size(); ++j) {
+          path[j].position.x = static_cast<double>(j);
+        }
+        state.set("path", path);
+      }
+      stop_flag.store(true);
+    };
+
+  std::atomic<int> reads{0};
+  auto reader = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      while (!stop_flag.load()) {
+        auto snapshot = state.get_safe<std::vector<geometry_msgs::msg::Pose>>("path");
+        // Every element index must equal its own position.x: proves the
+        // vector observed is internally consistent, never a mix of two
+        // different writes.
+        for (size_t j = 0; j < snapshot.size(); ++j) {
+          ASSERT_DOUBLE_EQ(snapshot[j].position.x, static_cast<double>(j));
+        }
+        reads.fetch_add(1);
+      }
+    };
+
+  std::vector<std::thread> threads;
+  threads.emplace_back(writer);
+  for (int i = 0; i < 3; ++i) {
+    threads.emplace_back(reader);
+  }
+
+  start_flag.store(true);
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  EXPECT_GT(reads.load(), 0);
+  SUCCEED();
+}

--- a/easynav_controller/include/easynav_controller/ControllerNode.hpp
+++ b/easynav_controller/include/easynav_controller/ControllerNode.hpp
@@ -136,6 +136,15 @@ private:
   rclcpp::CallbackGroup::SharedPtr realtime_cbg_;
 
   /**
+   * @brief Pluginlib loader used to dynamically load controller implementations.
+   *
+   * This allows runtime selection and loading of different controller strategies
+   * that inherit from ControllerMethodBase, using ROS pluginlib.
+   *
+   */
+  std::unique_ptr<pluginlib::ClassLoader<easynav::ControllerMethodBase>> controller_loader_;
+
+  /**
    * @brief Pointer to the controller method.
    *
    * This is the actual control algorithm that will be used.
@@ -148,14 +157,6 @@ private:
    * This is the current state of the navigation system.
    */
   const std::shared_ptr<const NavState> nav_state_;
-
-  /**
-   * @brief Pluginlib loader used to dynamically load controller implementations.
-   *
-   * This allows runtime selection and loading of different controller strategies
-   * that inherit from ControllerMethodBase, using ROS pluginlib.
-   */
-  std::unique_ptr<pluginlib::ClassLoader<easynav::ControllerMethodBase>> controller_loader_;
 };
 
 }  // namespace easynav

--- a/easynav_localizer/include/easynav_localizer/LocalizerNode.hpp
+++ b/easynav_localizer/include/easynav_localizer/LocalizerNode.hpp
@@ -117,11 +117,11 @@ private:
   /// @brief Callback group reserved for real-time operations.
   rclcpp::CallbackGroup::SharedPtr realtime_cbg_;
 
-  /// @brief Instance of the loaded localization plugin.
-  std::shared_ptr<LocalizerMethodBase> localizer_method_ {nullptr};
-
   /// @brief Plugin loader for LocalizerMethodBase implementations.
   std::unique_ptr<pluginlib::ClassLoader<easynav::LocalizerMethodBase>> localizer_loader_;
+
+  /// @brief Instance of the loaded localization plugin.
+  std::shared_ptr<LocalizerMethodBase> localizer_method_ {nullptr};
 };
 
 }  // namespace easynav

--- a/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
+++ b/easynav_sensors/include/easynav_sensors/SensorsNode.hpp
@@ -119,6 +119,16 @@ public:
 protected:
   /// @brief Sensor groups (set as group of keys in the NavState)
   std::map<std::string, std::vector<std::string>> groups_;
+
+  /// @brief Pluginlib class loader for PerceptionHandler plugins.
+  ///
+  /// Declared before \ref handler_list_ so it is destroyed *after* it: members are
+  /// destroyed in reverse declaration order, and each handler instance's vtable/code
+  /// lives inside the shared library this loader dlopen()s. Destroying the loader
+  /// (and therefore dlclose()-ing the library) before the instances would make their
+  /// destructors call into unloaded code.
+  std::unique_ptr<pluginlib::ClassLoader<PerceptionHandler>> handler_loader_;
+
   /// @brief vector of PerceptionHandler instances
   std::vector<std::shared_ptr<PerceptionHandler>> handler_list_;
 
@@ -140,9 +150,6 @@ private:
 
   /// @brief A flag to initialize groups in the NavState just once
   bool groups_initialized = false;
-
-  /// @brief Pluginlib class loader for PerceptionHandler plugins.
-  std::unique_ptr<pluginlib::ClassLoader<PerceptionHandler>> handler_loader_;
 
   /// @brief Map from ROS message type string to the built-in default plugin name.
   /// Initialised once in the constructor with the five standard handlers.

--- a/easynav_sensors/include/easynav_sensors/types/DetectionsPerception.hpp
+++ b/easynav_sensors/include/easynav_sensors/types/DetectionsPerception.hpp
@@ -22,6 +22,7 @@
 #ifndef EASYNAV_SENSORS_TYPES__DETECTIONSPERCEPTIONS_HPP_
 #define EASYNAV_SENSORS_TYPES__DETECTIONSPERCEPTIONS_HPP_
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -69,8 +70,63 @@ public:
       }();
   }
 
+  DetectionsPerception(const DetectionsPerception & other)
+  {
+    std::lock_guard<std::mutex> lock(other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+  }
+
+  DetectionsPerception & operator=(const DetectionsPerception & other)
+  {
+    if (this == &other) {
+      return *this;
+    }
+
+    std::scoped_lock lock(mutex_, other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+
+    return *this;
+  }
+
   /// \brief Detection3DArray data received from the an external processing system.
   vision_msgs::msg::Detection3DArray data;
+
+  /// \brief Atomically overwrites stamp/frame_id/data/valid from the subscription callback.
+  ///
+  /// Guards against a concurrent copy (e.g. via \c NavState::get_safe()) observing a
+  /// partially-updated object while this handler's RT-thread callback is writing.
+  void set_data(
+    const vision_msgs::msg::Detection3DArray & msg, const rclcpp::Time & msg_stamp,
+    const std::string & msg_frame_id)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stamp = msg_stamp;
+    frame_id = msg_frame_id;
+    new_data = true;
+    data = msg;
+    valid = true;
+  }
+
+  /// \brief Atomically reads and clears \ref new_data.
+  /// \return The value of \ref new_data before it was cleared.
+  bool consume_new_data()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const bool had_new_data = new_data;
+    new_data = false;
+    return had_new_data;
+  }
+
+protected:
+  mutable std::mutex mutex_;
 };
 
 /// \class DetectionsPerceptionsHandler

--- a/easynav_sensors/include/easynav_sensors/types/GNSSPerception.hpp
+++ b/easynav_sensors/include/easynav_sensors/types/GNSSPerception.hpp
@@ -22,6 +22,7 @@
 #ifndef EASYNAV_SENSORS_TYPES__GNSSPERCEPTIONS_HPP_
 #define EASYNAV_SENSORS_TYPES__GNSSPERCEPTIONS_HPP_
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -73,8 +74,63 @@ public:
       }();
   }
 
+  GNSSPerception(const GNSSPerception & other)
+  {
+    std::lock_guard<std::mutex> lock(other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+  }
+
+  GNSSPerception & operator=(const GNSSPerception & other)
+  {
+    if (this == &other) {
+      return *this;
+    }
+
+    std::scoped_lock lock(mutex_, other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+
+    return *this;
+  }
+
   /// \brief GNSS data received from the sensor.
   sensor_msgs::msg::NavSatFix data;
+
+  /// \brief Atomically overwrites stamp/frame_id/data/valid from the subscription callback.
+  ///
+  /// Guards against a concurrent copy (e.g. via \c NavState::get_safe()) observing a
+  /// partially-updated object while this handler's RT-thread callback is writing.
+  void set_data(
+    const sensor_msgs::msg::NavSatFix & msg, const rclcpp::Time & msg_stamp,
+    const std::string & msg_frame_id)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stamp = msg_stamp;
+    frame_id = msg_frame_id;
+    new_data = true;
+    data = msg;
+    valid = true;
+  }
+
+  /// \brief Atomically reads and clears \ref new_data.
+  /// \return The value of \ref new_data before it was cleared.
+  bool consume_new_data()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const bool had_new_data = new_data;
+    new_data = false;
+    return had_new_data;
+  }
+
+protected:
+  mutable std::mutex mutex_;
 };
 
 /// \class GNSSPerceptionHandler

--- a/easynav_sensors/include/easynav_sensors/types/IMUPerception.hpp
+++ b/easynav_sensors/include/easynav_sensors/types/IMUPerception.hpp
@@ -22,6 +22,7 @@
 #ifndef EASYNAV_SENSORS_TYPES__IMUPERCEPTIONS_HPP_
 #define EASYNAV_SENSORS_TYPES__IMUPERCEPTIONS_HPP_
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -71,8 +72,63 @@ public:
       }();
   }
 
+  IMUPerception(const IMUPerception & other)
+  {
+    std::lock_guard<std::mutex> lock(other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+  }
+
+  IMUPerception & operator=(const IMUPerception & other)
+  {
+    if (this == &other) {
+      return *this;
+    }
+
+    std::scoped_lock lock(mutex_, other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+
+    return *this;
+  }
+
   /// \brief IMU data received from the sensor.
   sensor_msgs::msg::Imu data;
+
+  /// \brief Atomically overwrites stamp/frame_id/data/valid from the subscription callback.
+  ///
+  /// Guards against a concurrent copy (e.g. via \c NavState::get_safe()) observing a
+  /// partially-updated object while this handler's RT-thread callback is writing.
+  void set_data(
+    const sensor_msgs::msg::Imu & msg, const rclcpp::Time & msg_stamp,
+    const std::string & msg_frame_id)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stamp = msg_stamp;
+    frame_id = msg_frame_id;
+    new_data = true;
+    data = msg;
+    valid = true;
+  }
+
+  /// \brief Atomically reads and clears \ref new_data.
+  /// \return The value of \ref new_data before it was cleared.
+  bool consume_new_data()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const bool had_new_data = new_data;
+    new_data = false;
+    return had_new_data;
+  }
+
+protected:
+  mutable std::mutex mutex_;
 };
 
 /// \class IMUPerceptionHandler

--- a/easynav_sensors/include/easynav_sensors/types/ImagePerception.hpp
+++ b/easynav_sensors/include/easynav_sensors/types/ImagePerception.hpp
@@ -22,7 +22,9 @@
 #ifndef EASYNAV_SENSORS_TYPES__IMAGEPERCEPTIONS_HPP_
 #define EASYNAV_SENSORS_TYPES__IMAGEPERCEPTIONS_HPP_
 
+#include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cv_bridge/cv_bridge.hpp"
@@ -69,11 +71,78 @@ public:
       }();
   }
 
+  ImagePerception(const ImagePerception & other)
+  {
+    std::lock_guard<std::mutex> lock(other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+  }
+
+  ImagePerception & operator=(const ImagePerception & other)
+  {
+    if (this == &other) {
+      return *this;
+    }
+
+    std::scoped_lock lock(mutex_, other.mutex_);
+    stamp = other.stamp;
+    frame_id = other.frame_id;
+    valid = other.valid;
+    new_data = other.new_data;
+    data = other.data;
+
+    return *this;
+  }
+
   /// \brief Image data received from the sensor.
   ///
   /// The matrix layout follows OpenCV conventions. The encoding and channel depth depend on upstream conversion
   /// (typically via cv_bridge).
   cv::Mat data;
+
+  /// \brief Atomically overwrites stamp/frame_id/data with a successfully decoded image and
+  /// marks the perception valid.
+  ///
+  /// Guards against a concurrent copy (e.g. via \c NavState::get_safe()) observing a
+  /// partially-updated object while this handler's RT-thread callback is writing.
+  void set_data(
+    cv::Mat && image, const rclcpp::Time & msg_stamp,
+    const std::string & msg_frame_id)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stamp = msg_stamp;
+    frame_id = msg_frame_id;
+    new_data = true;
+    data = std::move(image);
+    valid = true;
+  }
+
+  /// \brief Atomically records a failed decode: updates stamp/frame_id, marks invalid, and
+  /// leaves \ref data untouched (matches the pre-existing behavior on cv_bridge exceptions).
+  void mark_invalid(const rclcpp::Time & msg_stamp, const std::string & msg_frame_id)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stamp = msg_stamp;
+    frame_id = msg_frame_id;
+    new_data = true;
+    valid = false;
+  }
+
+  /// \brief Atomically reads and clears \ref new_data.
+  /// \return The value of \ref new_data before it was cleared.
+  bool consume_new_data()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const bool had_new_data = new_data;
+    new_data = false;
+    return had_new_data;
+  }
+
+protected:
+  mutable std::mutex mutex_;
 };
 
 /// \class ImagePerceptionHandler

--- a/easynav_sensors/src/easynav_sensors/types/DetectionsPerception.cpp
+++ b/easynav_sensors/src/easynav_sensors/types/DetectionsPerception.cpp
@@ -59,12 +59,8 @@ void DetectionsPerceptionsHandler::on_initialize()
     topic, rclcpp::QoS(1),
     [this, clock_type](const vision_msgs::msg::Detection3DArray::SharedPtr msg)
     {
-      perception_data_->stamp = rclcpp::Time(msg->header.stamp, clock_type);
-      perception_data_->frame_id = msg->header.frame_id;
-      perception_data_->new_data = true;
-
-      perception_data_->data = *msg;  // Copy the Detection3DArray message
-      perception_data_->valid = true;
+      perception_data_->set_data(
+        *msg, rclcpp::Time(msg->header.stamp, clock_type), msg->header.frame_id);
     },
     options);
 }
@@ -74,9 +70,7 @@ bool DetectionsPerceptionsHandler::cycle_rt(std::shared_ptr<NavState> nav_state)
   // Store the perception in the NavState
   nav_state->set(get_sensor_name(), perception_data_);
   // Check if there was new data to trigger process and reset new_data state
-  const bool should_trigger = perception_data_->new_data;
-  perception_data_->new_data = false;
-  return should_trigger;
+  return perception_data_->consume_new_data();
 }
 
 rclcpp::Time get_latest_detections_perceptions_stamp(const DetectionsPerceptions & perceptions)

--- a/easynav_sensors/src/easynav_sensors/types/GNSSPerception.cpp
+++ b/easynav_sensors/src/easynav_sensors/types/GNSSPerception.cpp
@@ -57,11 +57,8 @@ void GNSSPerceptionHandler::on_initialize()
     topic, rclcpp::QoS(1),
     [this, clock_type](const sensor_msgs::msg::NavSatFix::SharedPtr msg)
     {
-      perception_data_->stamp = rclcpp::Time(msg->header.stamp, clock_type);
-      perception_data_->frame_id = msg->header.frame_id;
-      perception_data_->new_data = true;
-      perception_data_->data = *msg;
-      perception_data_->valid = true;
+      perception_data_->set_data(
+        *msg, rclcpp::Time(msg->header.stamp, clock_type), msg->header.frame_id);
     },
     options);
 }
@@ -71,9 +68,7 @@ bool GNSSPerceptionHandler::cycle_rt(std::shared_ptr<NavState> nav_state)
   // Store the perception in the NavState
   nav_state->set(get_sensor_name(), perception_data_);
   // Check if there was new data to trigger process and reset new_data state
-  const bool should_trigger = perception_data_->new_data;
-  perception_data_->new_data = false;
-  return should_trigger;
+  return perception_data_->consume_new_data();
 }
 
 rclcpp::Time get_latest_gnss_perceptions_stamp(const GNSSPerceptions & perceptions)

--- a/easynav_sensors/src/easynav_sensors/types/IMUPerception.cpp
+++ b/easynav_sensors/src/easynav_sensors/types/IMUPerception.cpp
@@ -59,11 +59,8 @@ void IMUPerceptionHandler::on_initialize()
     topic, rclcpp::QoS(1),
     [this, clock_type](const sensor_msgs::msg::Imu::SharedPtr msg)
     {
-      perception_data_->stamp = rclcpp::Time(msg->header.stamp, clock_type);
-      perception_data_->frame_id = msg->header.frame_id;
-      perception_data_->new_data = true;
-      perception_data_->data = *msg;
-      perception_data_->valid = true;
+      perception_data_->set_data(
+        *msg, rclcpp::Time(msg->header.stamp, clock_type), msg->header.frame_id);
     },
     options);
 }
@@ -73,9 +70,7 @@ bool IMUPerceptionHandler::cycle_rt(std::shared_ptr<NavState> nav_state)
   // Store the perception in the NavState
   nav_state->set(get_sensor_name(), perception_data_);
   // Check if there was new data to trigger process and reset new_data state
-  const bool should_trigger = perception_data_->new_data;
-  perception_data_->new_data = false;
-  return should_trigger;
+  return perception_data_->consume_new_data();
 }
 
 rclcpp::Time get_latest_imu_perceptions_stamp(const IMUPerceptions & perceptions)

--- a/easynav_sensors/src/easynav_sensors/types/ImagePerception.cpp
+++ b/easynav_sensors/src/easynav_sensors/types/ImagePerception.cpp
@@ -60,19 +60,18 @@ void ImagePerceptionHandler::on_initialize()
     topic, rclcpp::QoS(1),
     [this, clock_type](const sensor_msgs::msg::Image::SharedPtr msg)
     {
-      perception_data_->stamp = rclcpp::Time(msg->header.stamp, clock_type);
-      perception_data_->frame_id = msg->header.frame_id;
-      perception_data_->new_data = true;
+      const auto msg_stamp = rclcpp::Time(msg->header.stamp, clock_type);
+      const auto & msg_frame_id = msg->header.frame_id;
 
       try {
         cv_bridge::CvImageConstPtr cv_ptr = cv_bridge::toCvShare(msg, msg->encoding);
-        perception_data_->data = cv_ptr->image.clone();  // clone to avoid sharing buffers
-        perception_data_->valid = true;
+        // clone to avoid sharing buffers
+        perception_data_->set_data(cv_ptr->image.clone(), msg_stamp, msg_frame_id);
       } catch (const cv_bridge::Exception & e) {
         RCLCPP_WARN(
           rclcpp::get_logger("ImagePerceptionHandler"),
           "cv_bridge exception: %s", e.what());
-        perception_data_->valid = false;
+        perception_data_->mark_invalid(msg_stamp, msg_frame_id);
       }
     },
     options);
@@ -83,9 +82,7 @@ bool ImagePerceptionHandler::cycle_rt(std::shared_ptr<NavState> nav_state)
   // Store the perception in the NavState
   nav_state->set(get_sensor_name(), perception_data_);
   // Check if there was new data to trigger process and reset new_data state
-  const bool should_trigger = perception_data_->new_data;
-  perception_data_->new_data = false;
-  return should_trigger;
+  return perception_data_->consume_new_data();
 }
 
 rclcpp::Time get_latest_image_perceptions_stamp(const ImagePerceptions & perceptions)

--- a/easynav_sensors/tests/CMakeLists.txt
+++ b/easynav_sensors/tests/CMakeLists.txt
@@ -22,3 +22,8 @@ ament_add_gtest(sensors_lifecycle_tests sensors_lifecycle_tests.cpp)
 target_link_libraries(sensors_lifecycle_tests
   ${PROJECT_NAME}
 )
+
+ament_add_gtest(perception_locking_tests perception_locking_tests.cpp)
+target_link_libraries(perception_locking_tests
+  ${PROJECT_NAME}
+)

--- a/easynav_sensors/tests/perception_locking_tests.cpp
+++ b/easynav_sensors/tests/perception_locking_tests.cpp
@@ -1,0 +1,514 @@
+// Copyright 2026 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the mutex-guarded copy/assignment/set_data/consume_new_data (and, for
+// ImagePerception, mark_invalid) added to the "Simple" perception types
+// (IMU/GNSS/Detections/Image). These types are shared into NavState via the
+// shared_ptr overload of NavState::set(), so the *same* live object a subscription
+// callback mutates can be read cross-thread (e.g. via NavState::get_safe(), which
+// copy-constructs it). Without their own locking, that copy could observe a
+// partially-written object. See bugs.md finding #5.
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "sensor_msgs/msg/imu.hpp"
+#include "sensor_msgs/msg/nav_sat_fix.hpp"
+#include "vision_msgs/msg/detection3_d_array.hpp"
+
+#include "easynav_sensors/types/IMUPerception.hpp"
+#include "easynav_sensors/types/GNSSPerception.hpp"
+#include "easynav_sensors/types/DetectionsPerception.hpp"
+#include "easynav_sensors/types/ImagePerception.hpp"
+
+#include "gtest/gtest.h"
+
+class PerceptionLockingTestCase : public ::testing::Test
+{
+protected:
+  ~PerceptionLockingTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp()
+  {
+    if (!initialized) {
+      rclcpp::init(0, nullptr);
+      initialized = true;
+    }
+  }
+
+  bool initialized {false};
+};
+
+namespace
+{
+// Builds a frame_id long enough that std::string reallocates on every write
+// (well past libstdc++'s ~15-byte SSO buffer), so a torn read is actually
+// observable rather than accidentally safe due to small-string optimization.
+std::string long_frame_id(int i)
+{
+  return "frame_" + std::string(64, static_cast<char>('a' + (i % 26))) + "_" + std::to_string(i);
+}
+}  // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IMUPerception
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_F(PerceptionLockingTestCase, ImuSetDataUpdatesAllFields)
+{
+  easynav::IMUPerception p;
+  sensor_msgs::msg::Imu msg;
+  msg.linear_acceleration.x = 1.0;
+  msg.linear_acceleration.y = 2.0;
+  msg.linear_acceleration.z = 3.0;
+
+  const rclcpp::Time stamp(123, 456, RCL_ROS_TIME);
+  p.set_data(msg, stamp, "imu_link");
+
+  EXPECT_EQ(p.frame_id, "imu_link");
+  EXPECT_EQ(p.stamp, stamp);
+  EXPECT_TRUE(p.valid);
+  EXPECT_TRUE(p.new_data);
+  EXPECT_DOUBLE_EQ(p.data.linear_acceleration.x, 1.0);
+  EXPECT_DOUBLE_EQ(p.data.linear_acceleration.y, 2.0);
+  EXPECT_DOUBLE_EQ(p.data.linear_acceleration.z, 3.0);
+}
+
+TEST_F(PerceptionLockingTestCase, ImuConsumeNewDataReturnsThenClears)
+{
+  easynav::IMUPerception p;
+  sensor_msgs::msg::Imu msg;
+  p.set_data(msg, rclcpp::Time(0, 0, RCL_ROS_TIME), "imu_link");
+
+  EXPECT_TRUE(p.consume_new_data());
+  EXPECT_FALSE(p.consume_new_data())
+    << "consume_new_data() must clear new_data; a second call must return false";
+  EXPECT_FALSE(p.new_data);
+}
+
+TEST_F(PerceptionLockingTestCase, ImuCopyConstructorIsIndependentSnapshot)
+{
+  easynav::IMUPerception p;
+  sensor_msgs::msg::Imu msg;
+  msg.linear_acceleration.x = 1.0;
+  p.set_data(msg, rclcpp::Time(1, 0, RCL_ROS_TIME), "imu_link_1");
+
+  easynav::IMUPerception snapshot(p);
+
+  sensor_msgs::msg::Imu msg2;
+  msg2.linear_acceleration.x = 99.0;
+  p.set_data(msg2, rclcpp::Time(2, 0, RCL_ROS_TIME), "imu_link_2");
+
+  EXPECT_EQ(snapshot.frame_id, "imu_link_1");
+  EXPECT_DOUBLE_EQ(snapshot.data.linear_acceleration.x, 1.0);
+  EXPECT_EQ(p.frame_id, "imu_link_2");
+  EXPECT_DOUBLE_EQ(p.data.linear_acceleration.x, 99.0);
+}
+
+TEST_F(PerceptionLockingTestCase, ImuCopyAssignmentIsIndependentSnapshot)
+{
+  easynav::IMUPerception p;
+  sensor_msgs::msg::Imu msg;
+  msg.linear_acceleration.x = 1.0;
+  p.set_data(msg, rclcpp::Time(1, 0, RCL_ROS_TIME), "imu_link_1");
+
+  easynav::IMUPerception snapshot;
+  snapshot = p;
+
+  sensor_msgs::msg::Imu msg2;
+  msg2.linear_acceleration.x = 99.0;
+  p.set_data(msg2, rclcpp::Time(2, 0, RCL_ROS_TIME), "imu_link_2");
+
+  EXPECT_EQ(snapshot.frame_id, "imu_link_1");
+  EXPECT_DOUBLE_EQ(snapshot.data.linear_acceleration.x, 1.0);
+  EXPECT_EQ(p.frame_id, "imu_link_2");
+}
+
+TEST_F(PerceptionLockingTestCase, ImuSelfCopyAssignmentIsNoop)
+{
+  easynav::IMUPerception p;
+  sensor_msgs::msg::Imu msg;
+  msg.linear_acceleration.x = 1.0;
+  p.set_data(msg, rclcpp::Time(1, 0, RCL_ROS_TIME), "imu_link");
+
+  p = p;  // NOLINT(clang-diagnostic-self-assign-overloaded)
+
+  EXPECT_EQ(p.frame_id, "imu_link");
+  EXPECT_DOUBLE_EQ(p.data.linear_acceleration.x, 1.0);
+}
+
+// Reproduces the hazard set_data()/the copy constructor are meant to close: a
+// writer thread repeatedly overwriting frame_id (forcing std::string
+// reallocation) while a reader thread concurrently copy-constructs (as
+// NavState::get_safe() would). Every observed snapshot must be internally
+// consistent — the frame_id string must never be seen half-written/corrupted,
+// and its numeric suffix must always parse back to a value within range.
+TEST_F(PerceptionLockingTestCase, ImuConcurrentSetDataDuringCopyConstruction)
+{
+  easynav::IMUPerception p;
+  std::atomic<bool> start_flag{false};
+  std::atomic<bool> stop_flag{false};
+  std::atomic<int> reads{0};
+
+  auto writer = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      for (int i = 0; i < 3000; ++i) {
+        sensor_msgs::msg::Imu msg;
+        msg.linear_acceleration.x = static_cast<double>(i);
+        p.set_data(msg, rclcpp::Time(i, 0, RCL_ROS_TIME), long_frame_id(i));
+      }
+      stop_flag.store(true);
+    };
+
+  auto reader = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      while (!stop_flag.load()) {
+        easynav::IMUPerception snapshot(p);
+        std::this_thread::yield();
+        // A torn/corrupted frame_id would very likely not match this prefix.
+        EXPECT_TRUE(snapshot.frame_id.empty() || snapshot.frame_id.substr(0, 6) == "frame_")
+          << "corrupted frame_id: " << snapshot.frame_id;
+        reads.fetch_add(1);
+      }
+    };
+
+  std::vector<std::thread> threads;
+  threads.emplace_back(writer);
+  threads.emplace_back(reader);
+  start_flag.store(true);
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  EXPECT_GT(reads.load(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GNSSPerception
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_F(PerceptionLockingTestCase, GnssSetDataUpdatesAllFields)
+{
+  easynav::GNSSPerception p;
+  sensor_msgs::msg::NavSatFix msg;
+  msg.latitude = 40.4;
+  msg.longitude = -3.7;
+  msg.altitude = 650.0;
+
+  const rclcpp::Time stamp(10, 0, RCL_ROS_TIME);
+  p.set_data(msg, stamp, "gnss_link");
+
+  EXPECT_EQ(p.frame_id, "gnss_link");
+  EXPECT_EQ(p.stamp, stamp);
+  EXPECT_TRUE(p.valid);
+  EXPECT_TRUE(p.new_data);
+  EXPECT_DOUBLE_EQ(p.data.latitude, 40.4);
+  EXPECT_DOUBLE_EQ(p.data.longitude, -3.7);
+  EXPECT_DOUBLE_EQ(p.data.altitude, 650.0);
+}
+
+TEST_F(PerceptionLockingTestCase, GnssConsumeNewDataReturnsThenClears)
+{
+  easynav::GNSSPerception p;
+  sensor_msgs::msg::NavSatFix msg;
+  p.set_data(msg, rclcpp::Time(0, 0, RCL_ROS_TIME), "gnss_link");
+
+  EXPECT_TRUE(p.consume_new_data());
+  EXPECT_FALSE(p.consume_new_data());
+}
+
+TEST_F(PerceptionLockingTestCase, GnssCopyConstructorIsIndependentSnapshot)
+{
+  easynav::GNSSPerception p;
+  sensor_msgs::msg::NavSatFix msg;
+  msg.latitude = 1.0;
+  p.set_data(msg, rclcpp::Time(1, 0, RCL_ROS_TIME), "gnss_link_1");
+
+  easynav::GNSSPerception snapshot(p);
+
+  sensor_msgs::msg::NavSatFix msg2;
+  msg2.latitude = 99.0;
+  p.set_data(msg2, rclcpp::Time(2, 0, RCL_ROS_TIME), "gnss_link_2");
+
+  EXPECT_EQ(snapshot.frame_id, "gnss_link_1");
+  EXPECT_DOUBLE_EQ(snapshot.data.latitude, 1.0);
+  EXPECT_DOUBLE_EQ(p.data.latitude, 99.0);
+}
+
+TEST_F(PerceptionLockingTestCase, GnssCopyAssignmentIsIndependentSnapshot)
+{
+  easynav::GNSSPerception p;
+  sensor_msgs::msg::NavSatFix msg;
+  msg.latitude = 1.0;
+  p.set_data(msg, rclcpp::Time(1, 0, RCL_ROS_TIME), "gnss_link_1");
+
+  easynav::GNSSPerception snapshot;
+  snapshot = p;
+
+  sensor_msgs::msg::NavSatFix msg2;
+  msg2.latitude = 99.0;
+  p.set_data(msg2, rclcpp::Time(2, 0, RCL_ROS_TIME), "gnss_link_2");
+
+  EXPECT_DOUBLE_EQ(snapshot.data.latitude, 1.0);
+  EXPECT_DOUBLE_EQ(p.data.latitude, 99.0);
+}
+
+TEST_F(PerceptionLockingTestCase, GnssConcurrentSetDataDuringCopyConstruction)
+{
+  easynav::GNSSPerception p;
+  std::atomic<bool> start_flag{false};
+  std::atomic<bool> stop_flag{false};
+  std::atomic<int> reads{0};
+
+  auto writer = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      for (int i = 0; i < 3000; ++i) {
+        sensor_msgs::msg::NavSatFix msg;
+        msg.latitude = static_cast<double>(i);
+        p.set_data(msg, rclcpp::Time(i, 0, RCL_ROS_TIME), long_frame_id(i));
+      }
+      stop_flag.store(true);
+    };
+
+  auto reader = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      while (!stop_flag.load()) {
+        easynav::GNSSPerception snapshot(p);
+        std::this_thread::yield();
+        EXPECT_TRUE(snapshot.frame_id.empty() || snapshot.frame_id.substr(0, 6) == "frame_")
+          << "corrupted frame_id: " << snapshot.frame_id;
+        reads.fetch_add(1);
+      }
+    };
+
+  std::vector<std::thread> threads;
+  threads.emplace_back(writer);
+  threads.emplace_back(reader);
+  start_flag.store(true);
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  EXPECT_GT(reads.load(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DetectionsPerception
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_F(PerceptionLockingTestCase, DetectionsSetDataUpdatesAllFields)
+{
+  easynav::DetectionsPerception p;
+  vision_msgs::msg::Detection3DArray msg;
+  msg.detections.resize(2);
+
+  const rclcpp::Time stamp(5, 0, RCL_ROS_TIME);
+  p.set_data(msg, stamp, "camera_link");
+
+  EXPECT_EQ(p.frame_id, "camera_link");
+  EXPECT_EQ(p.stamp, stamp);
+  EXPECT_TRUE(p.valid);
+  EXPECT_TRUE(p.new_data);
+  EXPECT_EQ(p.data.detections.size(), 2u);
+}
+
+TEST_F(PerceptionLockingTestCase, DetectionsConsumeNewDataReturnsThenClears)
+{
+  easynav::DetectionsPerception p;
+  vision_msgs::msg::Detection3DArray msg;
+  p.set_data(msg, rclcpp::Time(0, 0, RCL_ROS_TIME), "camera_link");
+
+  EXPECT_TRUE(p.consume_new_data());
+  EXPECT_FALSE(p.consume_new_data());
+}
+
+TEST_F(PerceptionLockingTestCase, DetectionsCopyConstructorIsIndependentSnapshot)
+{
+  easynav::DetectionsPerception p;
+  vision_msgs::msg::Detection3DArray msg;
+  msg.detections.resize(1);
+  p.set_data(msg, rclcpp::Time(1, 0, RCL_ROS_TIME), "camera_link_1");
+
+  easynav::DetectionsPerception snapshot(p);
+
+  vision_msgs::msg::Detection3DArray msg2;
+  msg2.detections.resize(5);
+  p.set_data(msg2, rclcpp::Time(2, 0, RCL_ROS_TIME), "camera_link_2");
+
+  EXPECT_EQ(snapshot.frame_id, "camera_link_1");
+  EXPECT_EQ(snapshot.data.detections.size(), 1u);
+  EXPECT_EQ(p.data.detections.size(), 5u);
+}
+
+TEST_F(PerceptionLockingTestCase, DetectionsConcurrentSetDataDuringCopyConstruction)
+{
+  easynav::DetectionsPerception p;
+  std::atomic<bool> start_flag{false};
+  std::atomic<bool> stop_flag{false};
+  std::atomic<int> reads{0};
+
+  auto writer = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      for (int i = 0; i < 2000; ++i) {
+        vision_msgs::msg::Detection3DArray msg;
+        // Varying size forces the internal vector to reallocate on (almost)
+        // every write, same hazard class as NavState's "path"/"goals" bug.
+        msg.detections.resize(1 + (i % 23));
+        p.set_data(msg, rclcpp::Time(i, 0, RCL_ROS_TIME), long_frame_id(i));
+      }
+      stop_flag.store(true);
+    };
+
+  auto reader = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      while (!stop_flag.load()) {
+        easynav::DetectionsPerception snapshot(p);
+        std::this_thread::yield();
+        // size() must always be sane; a torn read on the vector's internal
+        // pointers/size could otherwise report a garbage size or crash.
+        EXPECT_LE(snapshot.data.detections.size(), 23u);
+        reads.fetch_add(1);
+      }
+    };
+
+  std::vector<std::thread> threads;
+  threads.emplace_back(writer);
+  threads.emplace_back(reader);
+  start_flag.store(true);
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  EXPECT_GT(reads.load(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImagePerception
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_F(PerceptionLockingTestCase, ImageSetDataUpdatesAllFieldsAndIsValid)
+{
+  easynav::ImagePerception p;
+  cv::Mat img(2, 3, CV_8UC1, cv::Scalar(42));
+
+  const rclcpp::Time stamp(7, 0, RCL_ROS_TIME);
+  p.set_data(img.clone(), stamp, "camera_link");
+
+  EXPECT_EQ(p.frame_id, "camera_link");
+  EXPECT_EQ(p.stamp, stamp);
+  EXPECT_TRUE(p.valid);
+  EXPECT_TRUE(p.new_data);
+  EXPECT_EQ(p.data.rows, 2);
+  EXPECT_EQ(p.data.cols, 3);
+}
+
+TEST_F(PerceptionLockingTestCase, ImageMarkInvalidClearsValidButKeepsPreviousData)
+{
+  easynav::ImagePerception p;
+  cv::Mat img(2, 3, CV_8UC1, cv::Scalar(42));
+  p.set_data(img.clone(), rclcpp::Time(1, 0, RCL_ROS_TIME), "camera_link_1");
+  ASSERT_TRUE(p.valid);
+
+  p.mark_invalid(rclcpp::Time(2, 0, RCL_ROS_TIME), "camera_link_2");
+
+  EXPECT_FALSE(p.valid);
+  EXPECT_TRUE(p.new_data);
+  EXPECT_EQ(p.frame_id, "camera_link_2");
+  // Matches the pre-existing cv_bridge-exception behavior: data is left
+  // untouched on a failed decode, not cleared.
+  EXPECT_EQ(p.data.rows, 2);
+  EXPECT_EQ(p.data.cols, 3);
+}
+
+TEST_F(PerceptionLockingTestCase, ImageConsumeNewDataReturnsThenClears)
+{
+  easynav::ImagePerception p;
+  cv::Mat img(1, 1, CV_8UC1);
+  p.set_data(img.clone(), rclcpp::Time(0, 0, RCL_ROS_TIME), "camera_link");
+
+  EXPECT_TRUE(p.consume_new_data());
+  EXPECT_FALSE(p.consume_new_data());
+}
+
+TEST_F(PerceptionLockingTestCase, ImageCopyConstructorIsIndependentSnapshot)
+{
+  easynav::ImagePerception p;
+  cv::Mat img1(2, 2, CV_8UC1, cv::Scalar(1));
+  p.set_data(img1.clone(), rclcpp::Time(1, 0, RCL_ROS_TIME), "camera_link_1");
+
+  easynav::ImagePerception snapshot(p);
+
+  cv::Mat img2(4, 4, CV_8UC1, cv::Scalar(2));
+  p.set_data(img2.clone(), rclcpp::Time(2, 0, RCL_ROS_TIME), "camera_link_2");
+
+  EXPECT_EQ(snapshot.data.rows, 2);
+  EXPECT_EQ(snapshot.data.cols, 2);
+  EXPECT_EQ(p.data.rows, 4);
+  EXPECT_EQ(p.data.cols, 4);
+}
+
+// cv::Mat is itself reference-counted/shared-buffer; the point of set_data()
+// taking the lock is to make the (header, buffer) pair change atomically as
+// observed by a concurrent copy. Varying image size on every write forces a
+// new buffer allocation, so a torn read would show a rows/cols mismatch
+// against the buffer's actual size.
+TEST_F(PerceptionLockingTestCase, ImageConcurrentSetDataDuringCopyConstruction)
+{
+  easynav::ImagePerception p;
+  std::atomic<bool> start_flag{false};
+  std::atomic<bool> stop_flag{false};
+  std::atomic<int> reads{0};
+
+  auto writer = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      for (int i = 0; i < 1000; ++i) {
+        const int size = 1 + (i % 17);
+        cv::Mat img(size, size, CV_8UC1, cv::Scalar(static_cast<double>(i % 256)));
+        p.set_data(std::move(img), rclcpp::Time(i, 0, RCL_ROS_TIME), long_frame_id(i));
+      }
+      stop_flag.store(true);
+    };
+
+  auto reader = [&]() {
+      while (!start_flag.load()) {std::this_thread::yield();}
+      while (!stop_flag.load()) {
+        easynav::ImagePerception snapshot(p);
+        std::this_thread::yield();
+        if (!snapshot.data.empty()) {
+          EXPECT_EQ(snapshot.data.rows, snapshot.data.cols)
+            << "torn read: mismatched image dimensions";
+          EXPECT_EQ(
+            static_cast<size_t>(snapshot.data.total() * snapshot.data.elemSize()),
+            snapshot.data.dataend - snapshot.data.datastart)
+            << "torn read: buffer size does not match header dimensions";
+        }
+        reads.fetch_add(1);
+      }
+    };
+
+  std::vector<std::thread> threads;
+  threads.emplace_back(writer);
+  threads.emplace_back(reader);
+  start_flag.store(true);
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  EXPECT_GT(reads.load(), 0);
+}

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -318,7 +318,7 @@ GoalManager::comanded_pose_callback(geometry_msgs::msg::PoseStamped::UniquePtr m
 void
 GoalManager::update(NavState & nav_state)
 {
-  if (nav_state.get<State>("navigation_state") != state_) {
+  if (nav_state.get_safe<State>("navigation_state") != state_) {
     nav_state.set("navigation_state", state_);
   }
 
@@ -338,7 +338,7 @@ GoalManager::update(NavState & nav_state)
     return;
   }
 
-  const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
+  const auto & robot_pose = nav_state.get_safe<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
 
   easynav_interfaces::msg::NavigationControl feedback;
   feedback.type = easynav_interfaces::msg::NavigationControl::FEEDBACK;
@@ -347,7 +347,7 @@ GoalManager::update(NavState & nav_state)
   feedback.user_id = id_;
   feedback.nav_current_user_id = current_client_id_;
 
-  const auto & odom = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
+  const auto & odom = nav_state.get_safe<nav_msgs::msg::Odometry>("robot_pose");
 
   feedback.goals = goals_;
   feedback.current_pose.header = odom.header;
@@ -383,7 +383,7 @@ GoalManager::update(NavState & nav_state)
     nav_state.set("goals", goals_);
   }
 
-  const auto & goals = nav_state.get<nav_msgs::msg::Goals>("goals");
+  const auto & goals = nav_state.get_safe<nav_msgs::msg::Goals>("goals");
 
   if (goals != goals_) {
     nav_state.set("goals", goals_);
@@ -393,7 +393,7 @@ GoalManager::update(NavState & nav_state)
     set_finished();
   }
 
-  if (nav_state.get<State>("navigation_state") != state_) {
+  if (nav_state.get_safe<State>("navigation_state") != state_) {
     nav_state.set("navigation_state", state_);
   }
 

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -338,7 +338,7 @@ GoalManager::update(NavState & nav_state)
     return;
   }
 
-  const auto & robot_pose = nav_state.get_safe<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
+  const auto robot_pose = nav_state.get_safe<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
 
   easynav_interfaces::msg::NavigationControl feedback;
   feedback.type = easynav_interfaces::msg::NavigationControl::FEEDBACK;


### PR DESCRIPTION
Hi,

`NavState::get<T>()` returns an unsynchronized reference. `easynav_common/include/easynav_common/types/NavState.hpp:186-206`
  Returns `const T&` after releasing the internal lock; `set()` (line 104-126) mutates the
  object **in place** when the key already exists, so any `const auto& x = nav_state.get<T>(...)`
  is exposed to a concurrent unsynchronized write.

This PR adds `NavState::get_safe<T>()`, providing a way to get a  synchronized reference, as it returns `T` by value, with the copy made while `state_mutex_` is still held.

Only light type data is affected by this improvements:
* Heavy data, like PointClouds, are protected by another mechanism.
* Maps are currently only used by one thread (the non-rt). Use the new method would add an extra copy of potentially large data, and today it is not a problem.

`NavState::get_safe<T>()` should be used to get non-heavy data from the NavState which could be midified by other thread.

I hope it helps
