### PR TITLE
Fix unload plugins

### DIFF
--- a/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
+++ b/easynav_sensors/src/easynav_sensors/SensorsNode.cpp
@@ -71,7 +71,7 @@ SensorsNode::SensorsNode(const rclcpp::NodeOptions & options)
 
 SensorsNode::~SensorsNode()
 {
-  if (get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+  if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
     trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_SHUTDOWN);
   }
 }

--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -126,8 +126,18 @@ public:
   );
 
 private:
+  /// @brief Locks \ref parent_node_, returning nullptr if the owning SystemNode has
+  /// already been destroyed.
+  rclcpp_lifecycle::LifecycleNode::SharedPtr get_node() const;
+
   /// @brief Lifecycle node.
-  rclcpp_lifecycle::LifecycleNode::SharedPtr parent_node_;
+  ///
+  /// Held as a weak_ptr, not a shared_ptr: GoalManager is itself owned (by shared_ptr)
+  /// by the SystemNode passed here via shared_from_this() at construction. A strong
+  /// shared_ptr back to it would form a reference cycle (SystemNode -> GoalManager ->
+  /// SystemNode) that never reaches a zero refcount, so SystemNode — and everything it
+  /// owns, down to every plugin loaded via pluginlib — would never be destructed.
+  std::weak_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_;
 
   /// @brief Goal tolerance (translation and rotation).
   GoalTolerance goal_tolerance_ {};

--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -131,12 +131,6 @@ private:
   rclcpp_lifecycle::LifecycleNode::SharedPtr get_node() const;
 
   /// @brief Lifecycle node.
-  ///
-  /// Held as a weak_ptr, not a shared_ptr: GoalManager is itself owned (by shared_ptr)
-  /// by the SystemNode passed here via shared_from_this() at construction. A strong
-  /// shared_ptr back to it would form a reference cycle (SystemNode -> GoalManager ->
-  /// SystemNode) that never reaches a zero refcount, so SystemNode — and everything it
-  /// owns, down to every plugin loaded via pluginlib — would never be destructed.
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_;
 
   /// @brief Goal tolerance (translation and rotation).

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -75,19 +75,21 @@ GoalManager::GoalManager(
 {
   nav_state.set("navigation_state", state_);
 
-  parent_node_->declare_parameter("allow_preempt_goal", allow_preempt_goal_);
-  parent_node_->declare_parameter("position_tolerance", goal_tolerance_.position);
-  parent_node_->declare_parameter("height_tolerance", goal_tolerance_.height);
-  parent_node_->declare_parameter("angle_tolerance", goal_tolerance_.yaw);
-  parent_node_->declare_parameter("update_frequency", update_frequency_);
-  parent_node_->get_parameter("allow_preempt_goal", allow_preempt_goal_);
-  parent_node_->get_parameter("position_tolerance", goal_tolerance_.position);
-  parent_node_->get_parameter("height_tolerance", goal_tolerance_.height);
-  parent_node_->get_parameter("angle_tolerance", goal_tolerance_.yaw);
-  parent_node_->get_parameter("update_frequency", update_frequency_);
+  // Use the constructor parameter directly here, not parent_node_: it's a live
+  // shared_ptr for the duration of this constructor, no need to lock() it.
+  parent_node->declare_parameter("allow_preempt_goal", allow_preempt_goal_);
+  parent_node->declare_parameter("position_tolerance", goal_tolerance_.position);
+  parent_node->declare_parameter("height_tolerance", goal_tolerance_.height);
+  parent_node->declare_parameter("angle_tolerance", goal_tolerance_.yaw);
+  parent_node->declare_parameter("update_frequency", update_frequency_);
+  parent_node->get_parameter("allow_preempt_goal", allow_preempt_goal_);
+  parent_node->get_parameter("position_tolerance", goal_tolerance_.position);
+  parent_node->get_parameter("height_tolerance", goal_tolerance_.height);
+  parent_node->get_parameter("angle_tolerance", goal_tolerance_.yaw);
+  parent_node->get_parameter("update_frequency", update_frequency_);
   if (update_frequency_ <= 0.0) {
     RCLCPP_WARN(
-      parent_node_->get_logger(),
+      parent_node->get_logger(),
       "Parameter 'update_frequency' must be > 0.0 (got %.3f); falling back to 20.0",
       update_frequency_);
     update_frequency_ = 20.0;
@@ -99,20 +101,20 @@ GoalManager::GoalManager(
   nav_state.set("goal_tolerance.height", goal_tolerance_.height);
   nav_state.set("goal_tolerance.yaw", goal_tolerance_.yaw);
 
-  control_sub_ = parent_node_->create_subscription<easynav_interfaces::msg::NavigationControl>(
+  control_sub_ = parent_node->create_subscription<easynav_interfaces::msg::NavigationControl>(
     "easynav_control", 100,
     std::bind(&GoalManager::control_callback, this, std::placeholders::_1)
   );
 
-  comanded_pose_sub_ = parent_node_->create_subscription<geometry_msgs::msg::PoseStamped>(
+  comanded_pose_sub_ = parent_node->create_subscription<geometry_msgs::msg::PoseStamped>(
     "goal_pose", 100,
     std::bind(&GoalManager::comanded_pose_callback, this, std::placeholders::_1)
   );
 
-  control_pub_ = parent_node_->create_publisher<easynav_interfaces::msg::NavigationControl>(
+  control_pub_ = parent_node->create_publisher<easynav_interfaces::msg::NavigationControl>(
     "easynav_control", 100);
 
-  info_pub_ = parent_node_->create_publisher<easynav_interfaces::msg::GoalManagerInfo>(
+  info_pub_ = parent_node->create_publisher<easynav_interfaces::msg::GoalManagerInfo>(
     "easynav_manager_info", 100);
 
   id_ = "easynav_system";
@@ -129,7 +131,13 @@ GoalManager::GoalManager(
       return ret.str();
     });
 
-  // parent_node_->get_logger().set_level(rclcpp::Logger::Level::Debug);
+  // parent_node->get_logger().set_level(rclcpp::Logger::Level::Debug);
+}
+
+rclcpp_lifecycle::LifecycleNode::SharedPtr
+GoalManager::get_node() const
+{
+  return parent_node_.lock();
 }
 
 void
@@ -137,9 +145,12 @@ GoalManager::accept_request(
   const easynav_interfaces::msg::NavigationControl & msg,
   easynav_interfaces::msg::NavigationControl & response)
 {
-  nav_start_time_ = parent_node_->now();
+  auto node = get_node();
+  if (!node) {return;}
 
-  RCLCPP_DEBUG(parent_node_->get_logger(), "Accepted navigation request");
+  nav_start_time_ = node->now();
+
+  RCLCPP_DEBUG(node->get_logger(), "Accepted navigation request");
 
   goals_ = msg.goals;
 
@@ -156,19 +167,22 @@ GoalManager::control_callback(easynav_interfaces::msg::NavigationControl::Unique
 {
   if (msg->user_id == id_) {return;}  // Avoid self messages
 
-  RCLCPP_DEBUG(parent_node_->get_logger(), "Managing navigation control message received");
+  auto node = get_node();
+  if (!node) {return;}
+
+  RCLCPP_DEBUG(node->get_logger(), "Managing navigation control message received");
 
   easynav_interfaces::msg::NavigationControl response;
   response = *msg;
-  response.header.stamp = parent_node_->now();
+  response.header.stamp = node->now();
   response.seq = msg->seq + 1;
   response.user_id = id_;
 
   switch (msg->type) {
     case easynav_interfaces::msg::NavigationControl::REQUEST:
-      RCLCPP_DEBUG(parent_node_->get_logger(), "Navigation request");
+      RCLCPP_DEBUG(node->get_logger(), "Navigation request");
       if (msg->goals.goals.empty()) {
-        RCLCPP_DEBUG(parent_node_->get_logger(), "Rejected navigation request (empty goals)");
+        RCLCPP_DEBUG(node->get_logger(), "Rejected navigation request (empty goals)");
 
         response.status_message = "Goals are empty";
         response.type = easynav_interfaces::msg::NavigationControl::REJECT;
@@ -183,7 +197,7 @@ GoalManager::control_callback(easynav_interfaces::msg::NavigationControl::Unique
             }
             accept_request(*msg, response);
           } else {
-            RCLCPP_DEBUG(parent_node_->get_logger(),
+            RCLCPP_DEBUG(node->get_logger(),
               "Rejected navigation request (unable to preempt)");
 
             response.status_message = "Goal rejected; unable to preemp current active goal";
@@ -194,22 +208,22 @@ GoalManager::control_callback(easynav_interfaces::msg::NavigationControl::Unique
       }
       break;
     case easynav_interfaces::msg::NavigationControl::CANCEL:
-      RCLCPP_DEBUG(parent_node_->get_logger(), "Navigation cancelation requested");
+      RCLCPP_DEBUG(node->get_logger(), "Navigation cancelation requested");
 
       if (current_client_id_ != msg->user_id) {
-        RCLCPP_DEBUG(parent_node_->get_logger(), "Navigation cancelation rejected (not yours)");
+        RCLCPP_DEBUG(node->get_logger(), "Navigation cancelation rejected (not yours)");
         response.status_message = "Trying to cancel a navigation not commanded by you";
         response.type = easynav_interfaces::msg::NavigationControl::REJECT;
         response.nav_current_user_id = msg->user_id;
       } else {
         if (state_ == State::IDLE) {
-          RCLCPP_DEBUG(parent_node_->get_logger(),
+          RCLCPP_DEBUG(node->get_logger(),
             "Navigation cancelation rejected (not navigating)");
           response.status_message = "Nothing to cancel; easynav is idle";
           response.type = easynav_interfaces::msg::NavigationControl::ERROR;
           response.nav_current_user_id = msg->user_id;
         } else {
-          RCLCPP_DEBUG(parent_node_->get_logger(), "Navigation cancelation accepted");
+          RCLCPP_DEBUG(node->get_logger(), "Navigation cancelation accepted");
           goals_.goals.clear();
           response.status_message = "Goal cancelled";
           response.type = easynav_interfaces::msg::NavigationControl::CANCELLED;
@@ -219,7 +233,7 @@ GoalManager::control_callback(easynav_interfaces::msg::NavigationControl::Unique
       }
       break;
     default:
-      RCLCPP_WARN(parent_node_->get_logger(), "Received erroneous control message %d", msg->type);
+      RCLCPP_WARN(node->get_logger(), "Received erroneous control message %d", msg->type);
       response.status_message = "Unable to process message";
       response.type = easynav_interfaces::msg::NavigationControl::ERROR;
       response.nav_current_user_id = msg->user_id;
@@ -233,11 +247,14 @@ GoalManager::control_callback(easynav_interfaces::msg::NavigationControl::Unique
 void
 GoalManager::set_preempted()
 {
+  auto node = get_node();
+  if (!node) {return;}
+
   goals_.goals.clear();
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
-  response.header.stamp = parent_node_->now();
+  response.header.stamp = node->now();
   response.seq = last_control_->seq + 1;
   response.user_id = id_;
   response.type = easynav_interfaces::msg::NavigationControl::CANCELLED;
@@ -250,12 +267,15 @@ GoalManager::set_preempted()
 void
 GoalManager::set_finished()
 {
+  auto node = get_node();
+  if (!node) {return;}
+
   state_ = State::IDLE;
   goals_.goals.clear();
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
-  response.header.stamp = parent_node_->now();
+  response.header.stamp = node->now();
   response.seq = last_control_->seq + 1;
   response.user_id = id_;
   response.type = easynav_interfaces::msg::NavigationControl::FINISHED;
@@ -268,12 +288,15 @@ GoalManager::set_finished()
 void
 GoalManager::set_error(const std::string & reason)
 {
+  auto node = get_node();
+  if (!node) {return;}
+
   state_ = State::IDLE;
   goals_.goals.clear();
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
-  response.header.stamp = parent_node_->now();
+  response.header.stamp = node->now();
   response.seq = last_control_->seq + 1;
   response.user_id = id_;
   response.type = easynav_interfaces::msg::NavigationControl::ERROR;
@@ -286,12 +309,15 @@ GoalManager::set_error(const std::string & reason)
 void
 GoalManager::set_failed(const std::string & reason)
 {
+  auto node = get_node();
+  if (!node) {return;}
+
   state_ = State::IDLE;
   goals_.goals.clear();
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
-  response.header.stamp = parent_node_->now();
+  response.header.stamp = node->now();
   response.seq = last_control_->seq + 1;
   response.user_id = id_;
   response.type = easynav_interfaces::msg::NavigationControl::FAILED;
@@ -333,8 +359,11 @@ GoalManager::update(NavState & nav_state)
     return;
   }
 
+  auto node = get_node();
+  if (!node) {return;}
+
   if (!nav_state.has("robot_pose")) {
-    RCLCPP_WARN(parent_node_->get_logger(), "No robot pose at GoalManager::Update");
+    RCLCPP_WARN(node->get_logger(), "No robot pose at GoalManager::Update");
     return;
   }
 
@@ -342,7 +371,7 @@ GoalManager::update(NavState & nav_state)
 
   easynav_interfaces::msg::NavigationControl feedback;
   feedback.type = easynav_interfaces::msg::NavigationControl::FEEDBACK;
-  feedback.header.stamp = parent_node_->now();
+  feedback.header.stamp = node->now();
   feedback.seq = last_control_->seq + 1;
   feedback.user_id = id_;
   feedback.nav_current_user_id = current_client_id_;
@@ -352,7 +381,7 @@ GoalManager::update(NavState & nav_state)
   feedback.goals = goals_;
   feedback.current_pose.header = odom.header;
   feedback.current_pose.pose = odom.pose.pose;
-  feedback.navigation_time = parent_node_->now() - nav_start_time_;
+  feedback.navigation_time = node->now() - nav_start_time_;
 
   // Copy (not reference): check_goals() below may erase the front goal, which would
   // otherwise leave this dangling.
@@ -366,11 +395,11 @@ GoalManager::update(NavState & nav_state)
   // every cycle regardless, since the planner reacts to it as soon as a new goal's
   // timestamp is newer than its last planned one (see SystemNode::system_cycle()); delaying
   // that sync here would make the planner compute a path from stale/empty goals.
-  const auto now = parent_node_->now();
+  const auto now = node->now();
   const bool should_publish = first_update_ || (now - last_update_time_) >= update_period_;
 
   if (should_publish) {
-    RCLCPP_DEBUG(parent_node_->get_logger(), "Sending navigation feedback");
+    RCLCPP_DEBUG(node->get_logger(), "Sending navigation feedback");
     control_pub_->publish(feedback);
     *last_control_ = feedback;
     first_update_ = false;

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -200,7 +200,7 @@ GoalManager::control_callback(easynav_interfaces::msg::NavigationControl::Unique
             RCLCPP_DEBUG(node->get_logger(),
               "Rejected navigation request (unable to preempt)");
 
-            response.status_message = "Goal rejected; unable to preemp current active goal";
+            response.status_message = "Goal rejected; unable to preempt current active goal";
             response.type = easynav_interfaces::msg::NavigationControl::REJECT;
             response.nav_current_user_id = msg->user_id;
           }

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -72,13 +72,13 @@ SystemNode::SystemNode(const rclcpp::NodeOptions & options)
 
 SystemNode::~SystemNode()
 {
-  if (get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+  if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
     trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_SHUTDOWN);
   }
-  if (get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+  if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
     trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
   }
-  if (get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
+  if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
     trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN);
   }
 }

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -41,7 +41,8 @@ std::atomic<int64_t> g_shutdown_requested_at_ns{0};
 void handle_shutdown_signal(int /*signum*/)
 {
   constexpr int64_t kDebounceNs = 1'000'000'000;  // 1s
-  const int64_t now_ns = std::chrono::steady_clock::now().time_since_epoch().count();
+  const int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::steady_clock::now().time_since_epoch()).count();
 
   int64_t expected = 0;
   if (g_shutdown_requested_at_ns.compare_exchange_strong(expected, now_ns,

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
 #include <string>
 #include <atomic>
 #include <thread>
@@ -30,11 +33,34 @@
 
 using namespace std::chrono_literals;
 
+namespace
+{
+std::atomic_bool g_stop{false};
+std::atomic<int64_t> g_shutdown_requested_at_ns{0};
+
+void handle_shutdown_signal(int /*signum*/)
+{
+  constexpr int64_t kDebounceNs = 1'000'000'000;  // 1s
+  const int64_t now_ns = std::chrono::steady_clock::now().time_since_epoch().count();
+
+  int64_t expected = 0;
+  if (g_shutdown_requested_at_ns.compare_exchange_strong(expected, now_ns,
+    std::memory_order_relaxed))
+  {
+    g_stop.store(true, std::memory_order_relaxed);
+  } else if (now_ns - expected > kDebounceNs) {
+    std::_Exit(1);
+  }
+}
+}  // namespace
+
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
+  rclcpp::init(argc, argv, rclcpp::InitOptions(), rclcpp::SignalHandlerOptions::None);
+  std::signal(SIGINT, handle_shutdown_signal);
+  std::signal(SIGTERM, handle_shutdown_signal);
 
-  std::atomic_bool stop{false};
+  std::atomic_bool & stop = g_stop;
 
   std::thread rt_thread;
   {
@@ -108,13 +134,6 @@ int main(int argc, char ** argv)
       std::chrono::duration<double>(spin_time_nort)
     );
 
-    // Cooperative shutdown on SIGINT
-    rclcpp::on_shutdown([&](){
-        stop.store(true, std::memory_order_relaxed);
-        exe_rt.cancel();
-        exe_nort.cancel();
-    });
-
     // RT thread
     rt_thread = std::thread(
       [&, tf_node, tf_buffer, system_node, use_real_time]() {
@@ -167,15 +186,6 @@ int main(int argc, char ** argv)
     exe_rt.cancel();
     exe_nort.cancel();
 
-    // Wait for the RT thread to finish *before* exe_rt/exe_nort/system_node (and
-    // everything system_node owns, transitively down to every plugin's
-    // pluginlib::ClassLoader) are destroyed below. The RT thread's lambda captured
-    // system_node by value and calls exe_rt.spin_all() every cycle; joining it here,
-    // still inside this scope, guarantees it has released its own copy and stopped
-    // touching the executor before this thread's destructors run. Without this, the
-    // two threads race to release the last reference to system_node, so its final
-    // teardown (and every plugin instance vs. ClassLoader destruction order within
-    // it) can happen from either thread in an unspecified order.
     if (rt_thread.joinable()) {
       rt_thread.join();
     }

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -61,8 +61,6 @@ int main(int argc, char ** argv)
   std::signal(SIGINT, handle_shutdown_signal);
   std::signal(SIGTERM, handle_shutdown_signal);
 
-  std::atomic_bool & stop = g_stop;
-
   std::thread rt_thread;
   {
     // Executors live in this scope and will be destroyed after join().

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -166,12 +166,19 @@ int main(int argc, char ** argv)
     stop.store(true, std::memory_order_relaxed);
     exe_rt.cancel();
     exe_nort.cancel();
-  }
 
-
-  // Wait the RT thread to finish before shutting down ROS.
-  if (rt_thread.joinable()) {
-    rt_thread.join();
+    // Wait for the RT thread to finish *before* exe_rt/exe_nort/system_node (and
+    // everything system_node owns, transitively down to every plugin's
+    // pluginlib::ClassLoader) are destroyed below. The RT thread's lambda captured
+    // system_node by value and calls exe_rt.spin_all() every cycle; joining it here,
+    // still inside this scope, guarantees it has released its own copy and stopped
+    // touching the executor before this thread's destructors run. Without this, the
+    // two threads race to release the last reference to system_node, so its final
+    // teardown (and every plugin instance vs. ClassLoader destruction order within
+    // it) can happen from either thread in an unspecified order.
+    if (rt_thread.joinable()) {
+      rt_thread.join();
+    }
   }
 
   rclcpp::shutdown();


### PR DESCRIPTION
Hi,

For many months we have used to see some warnings finishing EasyNav:

```
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[system_main-1] [INFO] [1786434820.360225273] [rclcpp]: signal_handler(signum=2)
[rviz2-2] [INFO] [1786434820.360243333] [rclcpp]: signal_handler(signum=2)
[system_main-1] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[system_main-1]          at line 127 in /home/runner/conda-bld/bld/rattler-build_ros-rolling-class-loader_1782900710/work/ros-rolling-class-loader/src/work/src/class_loader.cpp
[system_main-1] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[system_main-1]          at line 127 in /home/runner/conda-bld/bld/rattler-build_ros-rolling-class-loader_1782900710/work/ros-rolling-class-loader/src/work/src/class_loader.cpp
[system_main-1] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[system_main-1]          at line 127 in /home/runner/conda-bld/bld/rattler-build_ros-rolling-class-loader_1782900710/work/ros-rolling-class-loader/src/work/src/class_loader.cpp
[system_main-1] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[system_main-1]          at line 127 in /home/runner/conda-bld/bld/rattler-build_ros-rolling-class-loader_1782900710/work/ros-rolling-class-loader/src/work/src/class_loader.cpp
[system_main-1] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[system_main-1]          at line 127 in /home/runner/conda-bld/bld/rattler-build_ros-rolling-class-loader_1782900710/work/ros-rolling-class-loader/src/work/src/class_loader.cpp
[system_main-1] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[system_main-1]          at line 127 in /home/runner/conda-bld/bld/rattler-build_ros-rolling-class-loader_1782900710/work/ros-rolling-class-loader/src/work/src/class_loader.cpp
[INFO] [system_main-1]: process has finished cleanly [pid 362946]
[INFO] [rviz2-2]: process has finished cleanly [pid 362948]
```

or 

```
[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[rviz2-2] [INFO] [1786436663.978319572] [rclcpp]: signal_handler(signum=2)
[system_main-1] [INFO] [1786436663.978419553] [rclcpp]: signal_handler(signum=2)
[system_main-1] [ERROR] [1786436663.983779891] [system_node]: Unable to start transition 7 (shutdown) from current state shuttingdown: Could not publish transition: publisher's context is invalid, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl_1782944810/work/ros-rolling-rcl/src/work/src/rcl/publisher.c:424, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl-lifecycle_1782944832/work/ros-rolling-rcl-lifecycle/src/work/src/rcl_lifecycle.c:390
[system_main-1] [ERROR] [1786436663.984785419] [sensors_node]: Unable to start transition 7 (shutdown) from current state shuttingdown: Could not publish transition: publisher's context is invalid, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl_1782944810/work/ros-rolling-rcl/src/work/src/rcl/publisher.c:424, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl-lifecycle_1782944832/work/ros-rolling-rcl-lifecycle/src/work/src/rcl_lifecycle.c:390
[system_main-1] [WARN] [1786436663.985120223] [rclcpp_lifecycle]: LifecycleNode is not shut down: Node still in state(3) in destructor
[system_main-1] [ERROR] [1786436663.987367571] [planner_node]: Unable to start transition 7 (shutdown) from current state shuttingdown: Could not publish transition: publisher's context is invalid, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl_1782944810/work/ros-rolling-rcl/src/work/src/rcl/publisher.c:424, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl-lifecycle_1782944832/work/ros-rolling-rcl-lifecycle/src/work/src/rcl_lifecycle.c:390
[system_main-1] [WARN] [1786436663.987531661] [rclcpp_lifecycle]: LifecycleNode is not shut down: Node still in state(3) in destructor
[system_main-1] [ERROR] [1786436663.989636287] [maps_manager_node]: Unable to start transition 7 (shutdown) from current state shuttingdown: Could not publish transition: publisher's context is invalid, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl_1782944810/work/ros-rolling-rcl/src/work/src/rcl/publisher.c:424, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl-lifecycle_1782944832/work/ros-rolling-rcl-lifecycle/src/work/src/rcl_lifecycle.c:390
[system_main-1] [WARN] [1786436663.990342961] [rclcpp_lifecycle]: LifecycleNode is not shut down: Node still in state(3) in destructor
[system_main-1] [ERROR] [1786436663.993301026] [localizer_node]: Unable to start transition 7 (shutdown) from current state shuttingdown: Could not publish transition: publisher's context is invalid, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl_1782944810/work/ros-rolling-rcl/src/work/src/rcl/publisher.c:424, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl-lifecycle_1782944832/work/ros-rolling-rcl-lifecycle/src/work/src/rcl_lifecycle.c:390
[system_main-1] [WARN] [1786436663.994046533] [rclcpp_lifecycle]: LifecycleNode is not shut down: Node still in state(3) in destructor
[system_main-1] [ERROR] [1786436663.996717610] [controller_node]: Unable to start transition 7 (shutdown) from current state shuttingdown: Could not publish transition: publisher's context is invalid, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl_1782944810/work/ros-rolling-rcl/src/work/src/rcl/publisher.c:424, at /home/runner/conda-bld/bld/rattler-build_ros-rolling-rcl-lifecycle_1782944832/work/ros-rolling-rcl-lifecycle/src/work/src/rcl_lifecycle.c:390
[system_main-1] [WARN] [1786436663.997384142] [rclcpp_lifecycle]: LifecycleNode is not shut down: Node still in state(3) in destructor
[system_main-1] [WARN] [1786436664.000345368] [rclcpp_lifecycle]: LifecycleNode is not shut down: Node still in state(3) in destructor
[INFO] [system_main-1]: process has finished cleanly [pid 383079]
[INFO] [rviz2-2]: process has finished cleanly [pid 383081]
``` 

## Root cause

- **Reference cycles via `shared_from_this()`.** `GoalManager`, `CostmapFilter`,
  `OctomapFilter` and `NavMapFilter` each stored the node passed to them as a
  **strong** `shared_ptr` instead of a `weak_ptr`. Since each is itself owned
  (transitively) by that same node, this is a cycle (`SystemNode → goal_manager_ →
  parent_node_ → SystemNode`, and similarly for the maps-manager filters) that never
  reaches a zero refcount — so **no node in the process was ever destructed** by
  normal C++ teardown, only reclaimed at OS process exit, which is what triggered
  `class_loader`'s live-instance check.

## Fixes

- **`GoalManager`, `CostmapFilter`, `OctomapFilter`, `NavMapFilter`**: `parent_node_`
  changed to `std::weak_ptr`, following the same `.lock()`-based `get_node()` pattern
  already used correctly by `MethodBase` and `PerceptionHandler`.
- **`ControllerNode`, `LocalizerNode`, `SensorsNode`, `CostmapMapsManager`**: the
  `pluginlib::ClassLoader` member was declared *after* the plugin instance(s) it
  creates, so on destruction the loader (`dlclose()`) ran *before* the instance whose
  code lives in that library — reordered so the loader outlives the instance(s), as
  `MapsManagerNode`/`PlannerNode` already did correctly.
- **`SystemNode`/`SensorsNode` destructors**: had `!=` where every sibling class uses
  `==` (e.g. `if (state != ACTIVE) trigger_transition(ACTIVE_SHUTDOWN)`), silently
  skipping the graceful lifecycle shutdown transition. Fixed to `==`.
- **`system_main.cpp` signal handling**: rclcpp's default SIGINT/SIGTERM handler
  finalizes the whole ROS context *from signal context*, before `main()` gets to
  gracefully deactivate/cleanup/shutdown every node — racing against (and breaking)
  the now-working destructors above. Replaced with `SignalHandlerOptions::None` +
  our own minimal handler (atomic flag only); `rclcpp::shutdown()` now runs exactly
  once, at the very end, after every node is already destructed in order.
  - Kept the "second signal force-quits" safety net rclcpp used to provide (in case
    graceful shutdown ever hangs), implemented as `std::_Exit()` on a signal arriving
    >1s after the first — the 1s debounce is needed because a single Ctrl-C reaches
    this process twice (terminal process-group delivery + `ros2 launch`'s own
    explicit forward).
- **`system_main.cpp` thread join order**: `rt_thread` (which captured `system_node`
  by value) is now joined *before* `exe_rt`/`exe_nort`/`system_node` are destroyed,
  removing a second, independent cross-thread teardown race on the executors.


