### PR TITLE
Fixed crash inside the error-handling path itself

### DIFF
--- a/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
+++ b/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
@@ -225,7 +225,7 @@ class GoalManagerClient:
                         case _:
                             self.node.get_logger().error(
                                 'State ACCEPTED_AND_NAVIGATING; Unexpected message: "%d": "%s"' %
-                                msg.type, msg.status_message)
+                                (msg.type, msg.status_message))
                             self.last_result = msg
                             self.state = ClientState.ERROR
                 case _:

--- a/easynav_support_py/test/test_goalmanager_client_unit.py
+++ b/easynav_support_py/test/test_goalmanager_client_unit.py
@@ -139,6 +139,29 @@ class TestGoalManagerClientUnit(unittest.TestCase):
             lambda: self.client.get_state() == ClientState.NAVIGATION_FAILED, timeout=2.0)
         self.assertTrue(ok, 'Expected NAVIGATION_FAILED after FAILED')
 
+    def test_unexpected_message_while_accepted_and_navigating(self):
+        # Regression test: _on_control()'s ACCEPTED_AND_NAVIGATING branch used to build
+        # its error log with `'...%d...%s' % msg.type, msg.status_message` — a missing
+        # tuple, so the string formatting itself raised TypeError (not enough arguments
+        # for format string) inside the subscription callback the moment an
+        # unrecognized message.type arrived in this state. ERROR is not handled by the
+        # ACCEPTED_AND_NAVIGATING branch (only FEEDBACK/FINISHED/FAILED/CANCELLED are),
+        # so it exercises the previously-broken `case _:` path.
+        self.client.send_goals(self.goals)
+        self._publish_and_wait(
+            self._srv_msg(NavigationControl.ACCEPT),
+            lambda: self.client.get_state() == ClientState.ACCEPTED_AND_NAVIGATING)
+
+        try:
+            ok = self._publish_and_wait(
+                self._srv_msg(NavigationControl.ERROR, 'unexpected'),
+                lambda: self.client.get_state() == ClientState.ERROR)
+        except TypeError as e:
+            self.fail(f'_on_control() raised {e!r} handling an unexpected message type')
+
+        self.assertTrue(ok, 'Expected ERROR after an unrecognized message type')
+        self.assertEqual(self.client.get_result().status_message, 'unexpected')
+
     def test_preempt_local(self):
         self.client.send_goals(self.goals)
         self._publish_and_wait(


### PR DESCRIPTION
Hi,

`GoalManagerClient._on_control()`'s `ACCEPTED_AND_NAVIGATING` branch built its error
log with `'...%d...%s' % msg.type, msg.status_message` — a missing tuple, so `%` only
applied to `msg.type`, leaving one `%s` placeholder unfilled. This raised an uncaught
`TypeError` **inside a ROS subscription callback** the moment an unrecognized
`msg.type` (e.g. `ERROR`) arrived while navigating — exactly the kind of message this
error-handling path exists to report. The two equivalent call sites in the
`SENT_PREEMPT` branch were already correctly parenthesized; this one was an isolated
typo.

**Fix**: wrap in a tuple — `% (msg.type, msg.status_message)`.

**Test**: added `test_unexpected_message_while_accepted_and_navigating`
(`test_goalmanager_client_unit.py`) — no existing test exercised this branch. Verified
as a genuine regression test by temporarily reintroducing the bug: the test failed
with the exact `TypeError('not enough arguments for format string')`; passed again
once the fix was restored.
