### PR TITLE
Minor bugs

### DIFF
--- a/easynav_common/include/easynav_common/YTSession.hpp
+++ b/easynav_common/include/easynav_common/YTSession.hpp
@@ -16,6 +16,10 @@
 #ifndef EASYNAV_COMMON_TYPES__YTSESSION_HPP_
 #define EASYNAV_COMMON_TYPES__YTSESSION_HPP_
 
+#include <unistd.h>
+
+#include <string>
+
 #include "easynav_common/Singleton.hpp"
 
 #include "yaets/tracing.hpp"
@@ -31,7 +35,7 @@ class YTSession : public yaets::TraceSession, public Singleton<YTSession>
 {
 public:
   explicit YTSession()
-  : yaets::TraceSession("/tmp/easynav.log")
+  : yaets::TraceSession(log_path())
   {}
 
   ~YTSession()
@@ -40,6 +44,13 @@ public:
   }
 
   SINGLETON_DEFINITIONS(YTSession)
+
+private:
+  /// \brief Per-process trace log path: /tmp/easynav_<pid>.log.
+  static std::string log_path()
+  {
+    return "/tmp/easynav_" + std::to_string(::getpid()) + ".log";
+  }
 };
 
 }  // namespace easynav

--- a/easynav_core/src/easynav_core/ControllerMethodBase.cpp
+++ b/easynav_core/src/easynav_core/ControllerMethodBase.cpp
@@ -114,8 +114,6 @@ ControllerMethodBase::is_inminent_collision(NavState & nav_state)
   const auto & tf_info = easynav::RTTFBuffer::getInstance()->get_tf_info();
   const auto & robot_frame = tf_info.robot_frame;
 
-  if (perceptions.empty()) {return false;}
-
   const double vx = twist.twist.linear.x;
   const double vy = twist.twist.linear.y;
   const double wz = twist.twist.angular.z;

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -63,6 +63,13 @@ MethodBase::isTime2RunRT()
 {
   auto node = parent_node_.lock();
   if (!node) {return false;}
+  if (rt_frequency_ <= 0.0f) {
+    RCLCPP_WARN_THROTTLE(
+      node->get_logger(), *node->get_clock(), 2000,
+      "[%s] RT cycle disabled: rt_frequency is %.3f (check the plugin's config)",
+      plugin_name_.c_str(), rt_frequency_);
+    return false;
+  }
   const auto now = node->now();
   const double target_cycle_time = 1.0 / rt_frequency_;
   const double cycle_time = (now - rt_last_ts_).seconds();
@@ -85,6 +92,13 @@ MethodBase::isTime2Run()
 {
   auto node = parent_node_.lock();
   if (!node) {return false;}
+  if (frequency_ <= 0.0f) {
+    RCLCPP_WARN_THROTTLE(
+      node->get_logger(), *node->get_clock(), 2000,
+      "[%s] cycle disabled: frequency is %.3f (check the plugin's config)",
+      plugin_name_.c_str(), frequency_);
+    return false;
+  }
   const auto now = node->now();
   const double target_cycle_time = 1.0 / frequency_;
   const double cycle_time = (now - last_ts_).seconds();

--- a/easynav_core/src/easynav_core/MethodBase.cpp
+++ b/easynav_core/src/easynav_core/MethodBase.cpp
@@ -16,6 +16,7 @@
 /// \brief Implementation of the base class MethodBase used in plugin-based EasyNav method components.
 
 #include <memory>
+#include <stdexcept>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -40,6 +41,13 @@ MethodBase::initialize(
   parent_node->get_parameter(plugin_name + ".rt_freq", rt_frequency_);
   parent_node->get_parameter(plugin_name + ".freq", frequency_);
 
+  if (rt_frequency_ <= 0.0f || frequency_ <= 0.0f) {
+    throw std::runtime_error(
+            "[" + plugin_name + "] Invalid frequency configuration: rt_freq=" +
+            std::to_string(rt_frequency_) + ", freq=" + std::to_string(frequency_) +
+            " (both must be > 0.0)");
+  }
+
   last_ts_ = parent_node->now();
   rt_last_ts_ = parent_node->now();
 
@@ -63,13 +71,6 @@ MethodBase::isTime2RunRT()
 {
   auto node = parent_node_.lock();
   if (!node) {return false;}
-  if (rt_frequency_ <= 0.0f) {
-    RCLCPP_WARN_THROTTLE(
-      node->get_logger(), *node->get_clock(), 2000,
-      "[%s] RT cycle disabled: rt_frequency is %.3f (check the plugin's config)",
-      plugin_name_.c_str(), rt_frequency_);
-    return false;
-  }
   const auto now = node->now();
   const double target_cycle_time = 1.0 / rt_frequency_;
   const double cycle_time = (now - rt_last_ts_).seconds();
@@ -92,13 +93,6 @@ MethodBase::isTime2Run()
 {
   auto node = parent_node_.lock();
   if (!node) {return false;}
-  if (frequency_ <= 0.0f) {
-    RCLCPP_WARN_THROTTLE(
-      node->get_logger(), *node->get_clock(), 2000,
-      "[%s] cycle disabled: frequency is %.3f (check the plugin's config)",
-      plugin_name_.c_str(), frequency_);
-    return false;
-  }
   const auto now = node->now();
   const double target_cycle_time = 1.0 / frequency_;
   const double cycle_time = (now - last_ts_).seconds();

--- a/easynav_sensors/src/easynav_sensors/types/PointPerception.cpp
+++ b/easynav_sensors/src/easynav_sensors/types/PointPerception.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <string>
 #include <vector>
 #include <optional>
@@ -410,9 +411,9 @@ PointPerceptionsOpsView::downsample(double resolution)
       const float z_val = collapse_z_ ? collapse_val_z_ : pt.z;
 
       VoxelKey key{
-        static_cast<int>(pt.x * inv_res),
-        static_cast<int>(pt.y * inv_res),
-        static_cast<int>(z_val * inv_res)};
+        static_cast<int>(std::floor(pt.x * inv_res)),
+        static_cast<int>(std::floor(pt.y * inv_res)),
+        static_cast<int>(std::floor(z_val * inv_res))};
 
       if (voxel_set.insert(key).second) {
         indices[write_idx++] = idx;

--- a/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
+++ b/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
@@ -48,7 +48,6 @@ class GoalManagerClient:
         self.node = node
 
         self.id = self.node.get_name() + '_goal_manager_client'
-        self.id = self.node.get_name() + '_goal_manager_client'
 
         self.control_topic = 'easynav_control'
         self.goal_topic = 'goal_pose'
@@ -182,7 +181,7 @@ class GoalManagerClient:
                             self.state = ClientState.ERROR
                         case _:
                             self.node.get_logger().error(
-                                'State SENT_PREEMPT; Unexpected message: "%d": "%s"' %
+                                'State SENT_GOAL; Unexpected message: "%d": "%s"' %
                                 (msg.type, msg.status_message))
                             self.state = ClientState.ERROR
                 case ClientState.SENT_PREEMPT:

--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -190,6 +190,12 @@ private:
 
   /// @brief Internal goal state.
   State state_ {State::IDLE};
+
+  /// @brief Value of "navigation_state" as last pushed to NavState by this class
+  /// (the sole writer of that key). Lets update() detect whether state_ has since
+  /// diverged without reading the key back from NavState (a lock + copy) just to
+  /// compare it against a value only this class ever wrote.
+  State last_synced_navigation_state_ {State::IDLE};
 };
 
 }  // namespace easynav

--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -192,10 +192,12 @@ private:
   State state_ {State::IDLE};
 
   /// @brief Value of "navigation_state" as last pushed to NavState by this class
-  /// (the sole writer of that key). Lets update() detect whether state_ has since
-  /// diverged without reading the key back from NavState (a lock + copy) just to
-  /// compare it against a value only this class ever wrote.
+  /// (the sole writer of that key).
   State last_synced_navigation_state_ {State::IDLE};
+
+  /// @brief True once NavState's "goals" has been synced to an empty Goals() since
+  /// the last time goals_ became non-empty (see accept_request()).
+  bool goals_synced_empty_ {true};
 };
 
 }  // namespace easynav

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -251,7 +251,7 @@ void
 GoalManager::set_finished()
 {
   state_ = State::IDLE;
-  goals_.goals.clear();
+  goals_ = nav_msgs::msg::Goals();
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
@@ -269,7 +269,7 @@ void
 GoalManager::set_error(const std::string & reason)
 {
   state_ = State::IDLE;
-  goals_.goals.clear();
+  goals_ = nav_msgs::msg::Goals();
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
@@ -287,7 +287,7 @@ void
 GoalManager::set_failed(const std::string & reason)
 {
   state_ = State::IDLE;
-  goals_.goals.clear();
+  goals_ = nav_msgs::msg::Goals();
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
@@ -318,8 +318,9 @@ GoalManager::comanded_pose_callback(geometry_msgs::msg::PoseStamped::UniquePtr m
 void
 GoalManager::update(NavState & nav_state)
 {
-  if (nav_state.get_safe<State>("navigation_state") != state_) {
+  if (last_synced_navigation_state_ != state_) {
     nav_state.set("navigation_state", state_);
+    last_synced_navigation_state_ = state_;
   }
 
    // Keep published tolerances in sync with current parameters
@@ -328,8 +329,10 @@ GoalManager::update(NavState & nav_state)
   nav_state.set("goal_tolerance.yaw", goal_tolerance_.yaw);
 
   if (state_ == State::IDLE) {
-    goals_ = nav_msgs::msg::Goals();
-    nav_state.set("goals", goals_);
+    if (!goals_.goals.empty()) {
+      goals_ = nav_msgs::msg::Goals();
+      nav_state.set("goals", goals_);
+    }
     return;
   }
 
@@ -338,7 +341,8 @@ GoalManager::update(NavState & nav_state)
     return;
   }
 
-  const auto robot_pose = nav_state.get_safe<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
+  const auto odom = nav_state.get_safe<nav_msgs::msg::Odometry>("robot_pose");
+  const auto & robot_pose = odom.pose.pose;
 
   easynav_interfaces::msg::NavigationControl feedback;
   feedback.type = easynav_interfaces::msg::NavigationControl::FEEDBACK;
@@ -346,8 +350,6 @@ GoalManager::update(NavState & nav_state)
   feedback.seq = last_control_->seq + 1;
   feedback.user_id = id_;
   feedback.nav_current_user_id = current_client_id_;
-
-  const auto & odom = nav_state.get_safe<nav_msgs::msg::Odometry>("robot_pose");
 
   feedback.goals = goals_;
   feedback.current_pose.header = odom.header;
@@ -393,8 +395,9 @@ GoalManager::update(NavState & nav_state)
     set_finished();
   }
 
-  if (nav_state.get_safe<State>("navigation_state") != state_) {
+  if (last_synced_navigation_state_ != state_) {
     nav_state.set("navigation_state", state_);
+    last_synced_navigation_state_ = state_;
   }
 
   if (should_publish && info_pub_->get_subscription_count() > 0) {

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -142,6 +142,7 @@ GoalManager::accept_request(
   RCLCPP_DEBUG(parent_node_->get_logger(), "Accepted navigation request");
 
   goals_ = msg.goals;
+  goals_synced_empty_ = false;
 
   current_client_id_ = msg.user_id;
   response.status_message = "Goal accepted";
@@ -329,9 +330,10 @@ GoalManager::update(NavState & nav_state)
   nav_state.set("goal_tolerance.yaw", goal_tolerance_.yaw);
 
   if (state_ == State::IDLE) {
-    if (!goals_.goals.empty()) {
+    if (!goals_synced_empty_) {
       goals_ = nav_msgs::msg::Goals();
       nav_state.set("goals", goals_);
+      goals_synced_empty_ = true;
     }
     return;
   }

--- a/easynav_system/tests/goalmanager_tests.cpp
+++ b/easynav_system/tests/goalmanager_tests.cpp
@@ -607,6 +607,14 @@ TEST_F(GoalManagerTestCase, simple_nav_node)
   req_goals = gm_server->get_goals();
   ASSERT_TRUE(req_goals.goals.empty());
 
+  // NavState's "goals" must also reflect the cancellation, not just the server's
+  // internal goals_ member -- CANCEL clears goals_ synchronously in the callback,
+  // before update() ever sees the transition, so a guard keyed off goals_.goals
+  // alone would skip republishing and leave NavState stuck on the last non-empty
+  // value.
+  const auto nav_state_goals = nav_state->get<nav_msgs::msg::Goals>("goals");
+  ASSERT_TRUE(nav_state_goals.goals.empty());
+
   last_control = gm_client->get_last_control();
   last_feedback = gm_client->get_feedback();
   last_result = gm_client->get_result();

--- a/easynav_tools/easynav_tools/cli/timetats.py
+++ b/easynav_tools/easynav_tools/cli/timetats.py
@@ -32,8 +32,8 @@ class TimeStatsVerb(VerbExtension):
         parser.add_argument(
             '--pid', type=int, default=None,
             help='PID of the EasyNav process to read stats from. Defaults to '
-                 'auto-discovering the most recently started instance; only needed '
-                 'when more than one EasyNav process is running on this host.')
+                 'auto-discovering the most recently modified /tmp/easynav_<pid>.log; '
+                 'only needed when more than one EasyNav process is running on this host.')
 
     def main(self, *, args):
         try:

--- a/easynav_tools/easynav_tools/cli/timetats.py
+++ b/easynav_tools/easynav_tools/cli/timetats.py
@@ -29,10 +29,15 @@ class TimeStatsVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         add_arguments(parser)
         parser.add_argument('--duration', type=float, default=5000.0, help='Seconds to run')
+        parser.add_argument(
+            '--pid', type=int, default=None,
+            help='PID of the EasyNav process to read stats from. Defaults to '
+                 'auto-discovering the most recently started instance; only needed '
+                 'when more than one EasyNav process is running on this host.')
 
     def main(self, *, args):
         try:
-            log_reader = LogReader()
+            log_reader = LogReader(pid=args.pid)
 
             t_end = time.time() + args.duration
             while time.time() < t_end:

--- a/easynav_tools/easynav_tools/controller/ros_controllers.py
+++ b/easynav_tools/easynav_tools/controller/ros_controllers.py
@@ -252,10 +252,16 @@ def _discover_log_path(pid: int | None = None) -> str | None:
     if pid is not None:
         return f'/tmp/easynav_{pid}.log'
 
-    candidates = glob.glob(_LOG_GLOB)
-    if not candidates:
+    dated_candidates = []
+    for path in glob.glob(_LOG_GLOB):
+        try:
+            dated_candidates.append((os.path.getmtime(path), path))
+        except FileNotFoundError:
+            # Deleted/rotated between glob() and getmtime(); skip it.
+            continue
+    if not dated_candidates:
         return None
-    return max(candidates, key=os.path.getmtime)
+    return max(dated_candidates)[1]
 
 
 # -------- Running stats (Welford) --------

--- a/easynav_tools/easynav_tools/controller/ros_controllers.py
+++ b/easynav_tools/easynav_tools/controller/ros_controllers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import math
 import os
 import re
@@ -234,8 +235,27 @@ class NavStateProcessor():
 
 
 # ---------- Time stats config ----------
-_LOG_PATH = '/tmp/easynav.log'
+# Each EasyNav process writes its own /tmp/easynav_<pid>.log (a single shared
+# /tmp/easynav.log broke with multiple concurrent instances on the same host).
+_LOG_GLOB = '/tmp/easynav_*.log'
 _LOG_RE = re.compile(r'^(?P<name>\S+)\s+(?P<start>\d+)\s+(?P<end>\d+)\s*$')
+
+
+def _discover_log_path(pid: int | None = None) -> str | None:
+    """Resolve the trace-log path for a running EasyNav instance.
+
+    With an explicit pid, targets that instance directly. Otherwise, auto-discovers
+    among currently-present /tmp/easynav_<pid>.log files, picking the most recently
+    modified one if more than one EasyNav instance is running. Returns None if no
+    pid was given and no log file exists yet (e.g. EasyNav hasn't started).
+    """
+    if pid is not None:
+        return f'/tmp/easynav_{pid}.log'
+
+    candidates = glob.glob(_LOG_GLOB)
+    if not candidates:
+        return None
+    return max(candidates, key=os.path.getmtime)
 
 
 # -------- Running stats (Welford) --------
@@ -276,8 +296,9 @@ def _sort_key_suffix(full: str) -> tuple[str, str]:
 
 class LogReader:
 
-    def __init__(self):
+    def __init__(self, pid: int | None = None):
         # ---- Time stats state (tailing the log) ----
+        self._log_path = _discover_log_path(pid)
         self._log_fh = None
         self._log_inode = None
         self._log_pos = 0
@@ -285,8 +306,15 @@ class LogReader:
 
     def _open_log_if_needed(self) -> None:
         """Open the log file if available, preserving position; handle rotation/truncation."""
+        if self._log_path is None:
+            # No pid was given and no instance was running yet at construction time;
+            # keep looking in case one has started since.
+            self._log_path = _discover_log_path()
+            if self._log_path is None:
+                return
+
         try:
-            st = os.stat(_LOG_PATH)
+            st = os.stat(self._log_path)
         except FileNotFoundError:
             # file missing: close if we had it
             if self._log_fh:
@@ -301,7 +329,7 @@ class LogReader:
 
         if self._log_fh is None:
             # first open: read from start to accumulate history
-            self._log_fh = open(_LOG_PATH, 'r', encoding='utf-8', errors='ignore')
+            self._log_fh = open(self._log_path, 'r', encoding='utf-8', errors='ignore')
             self._log_inode = st.st_ino
             self._log_pos = 0
             return
@@ -315,7 +343,7 @@ class LogReader:
                     self._log_fh.close()
                 except Exception:
                     pass
-                self._log_fh = open(_LOG_PATH, 'r', encoding='utf-8', errors='ignore')
+                self._log_fh = open(self._log_path, 'r', encoding='utf-8', errors='ignore')
                 self._log_inode = st.st_ino
                 self._log_pos = 0
         except Exception:
@@ -376,7 +404,7 @@ class LogReader:
         rows = []
         for full_name, d in sorted(self._ts_stats.items(), key=lambda kv: _sort_key_suffix(kv[0])):
             short = _shorten_name(full_name)
-            exec_mean, exec_std = d['exec'].as_tuple()            # μs
+            exec_mean, exec_std = d['exec'].as_tuple()            # ms
             elap_mean, elap_std = d['elapsed'].as_tuple()         # ms
             freq_mean, freq_std = d['freq'].as_tuple()            # Hz
             rows.append((short, (exec_mean, exec_std),


### PR DESCRIPTION
Hi,

There were a set of pending minor bugs to be fixed. This PR addresses them:


- **`YTSession`**: per-process log path (`/tmp/easynav_<pid>.log`) instead of a fixed path shared across instances.
- **`GoalManager::update()`**: avoids duplicate `NavState` reads (`robot_pose`, `navigation_state`) and stops republishing an empty `Goals()` on every idle cycle.
- **`GoalManager::set_finished/set_error/set_failed`**: fully clear `goals_` (previously only the vector, leaving a stale `header`).
- **`ControllerMethodBase::is_inminent_collision()`**: removes a dead, duplicated `perceptions.empty()` check.
- **`PointPerception::downsample()`**: uses `std::floor()` instead of truncating when bucketing the voxel grid (avoids asymmetry around the origin).
- **`goal_manager_client.py`**: fixes the state name in the `SENT_GOAL` branch's log message and removes a duplicate `self.id` assignment.
- **`MethodBase::isTime2Run()/isTime2RunRT()`**: logs a warning if `frequency_`/`rt_frequency_` is `0` instead of silently disabling the plugin.
- **`ros_controllers.py`**: fixes a unit comment (`μs` → `ms`) and adds auto-discovery/`--pid` support for the per-process log.

I hope it helps!!