### PR TITLE
Bug fixes

### DIFF
--- a/easynav_common/include/easynav_common/CircularBuffer.hpp
+++ b/easynav_common/include/easynav_common/CircularBuffer.hpp
@@ -169,16 +169,6 @@ public:
     return true;
   }
 
-  /// \brief Get a const reference to the newest element without removing it.
-  const T & latest_ref() const
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    const std::size_t newest_index =
-      (head_ + capacity_ - 1) % capacity_;
-    return buffer_[newest_index];
-  }
-
   // DEBUG ONLY: raw access to slots
   struct DebugSlotView
   {

--- a/easynav_common/include/easynav_common/Singleton.hpp
+++ b/easynav_common/include/easynav_common/Singleton.hpp
@@ -30,23 +30,34 @@ public:
   template<typename ... Args>
   static C * getInstance(Args &&... args)
   {
-    std::call_once(init_flag_, [&]() {
-        instance_ = std::make_unique<C>(std::forward<Args>(args)...);
-    });
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!instance_) {
+      instance_ = std::make_unique<C>(std::forward<Args>(args)...);
+    }
     return instance_.get();
   }
 
+  /// \brief Destroy the current instance, if any; the next getInstance()/get() call
+  /// creates a fresh one.
+  ///
+  /// \warning Only safe to call when no other thread may still be dereferencing a
+  /// \c C* obtained from an earlier getInstance()/get() call -- that pointer's
+  /// lifetime is tied to the destroyed instance, and no amount of locking here can
+  /// protect a caller who is already holding and using it (the lock only serializes
+  /// this class's own instance_/mutex_ bookkeeping against concurrent getInstance()/
+  /// removeInstance() calls). Intended for sequential use, e.g. resetting singleton
+  /// state between test cases, not for tearing down an instance while it may still
+  /// be in use elsewhere.
   static void removeInstance()
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     instance_.reset();
-    init_flag_ = std::once_flag();
   }
 
   template<typename ... Args>
   static C & get(Args &&... args)
   {
-    getInstance(std::forward<Args>(args)...);
-    return *instance_;
+    return *getInstance(std::forward<Args>(args)...);
   }
 
 protected:
@@ -58,14 +69,14 @@ protected:
 
 private:
   static std::unique_ptr<C> instance_;
-  static std::once_flag init_flag_;
+  static std::mutex mutex_;
 };
 
 template<class C>
 std::unique_ptr<C> Singleton<C>::instance_ = nullptr;
 
 template<class C>
-std::once_flag Singleton<C>::init_flag_;
+std::mutex Singleton<C>::mutex_;
 
 #define SINGLETON_DEFINITIONS(ClassName) \
 public: \

--- a/easynav_sensors/include/easynav_sensors/types/PointPerception.hpp
+++ b/easynav_sensors/include/easynav_sensors/types/PointPerception.hpp
@@ -180,12 +180,6 @@ public:
     data.points.resize(size);
   }
 
-  /// \brief Retrieves the most recent buffered perception (independently of it has a valid TF) without removing it from the buffer.
-  const PointPerceptionBufferType & get_last_perception() const
-  {
-    return buffer.latest_ref();
-  }
-
   void integrate_pending_perceptions()
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -499,11 +493,6 @@ public:
   /// \return Concatenated point cloud.
   pcl::PointCloud<pcl::PointXYZ> as_points() const;
 
-  /// \brief Retrieves the filtered point cloud for a specific perception.
-  /// \param idx Index of the target perception in the underlying container.
-  /// \return Const reference to the filtered point cloud.
-  const pcl::PointCloud<pcl::PointXYZ> & as_points(int idx) const;
-
   /// \brief Configures fusion of all perceptions into a common frame.
   ///
   /// This method does not immediately build a fused point cloud. Instead, it stores the target frame
@@ -589,9 +578,6 @@ private:
   double post_max_[3] {0.0, 0.0, 0.0};
   bool use_post_min_[3] {false, false, false};
   bool use_post_max_[3] {false, false, false};
-
-  // Temporary storage for as_points(int)
-  mutable pcl::PointCloud<pcl::PointXYZ> tmp_single_cloud_;
 };
 
 }  // namespace easynav

--- a/easynav_sensors/src/easynav_sensors/types/PointPerception.cpp
+++ b/easynav_sensors/src/easynav_sensors/types/PointPerception.cpp
@@ -559,63 +559,6 @@ PointPerceptionsOpsView::as_points() const
   return out;
 }
 
-const pcl::PointCloud<pcl::PointXYZ> &
-PointPerceptionsOpsView::as_points(int idx) const
-{
-  tmp_single_cloud_.clear();
-  tmp_single_cloud_.height = 1;
-  tmp_single_cloud_.is_dense = false;
-
-  if (idx < 0 || static_cast<std::size_t>(idx) >= perceptions_.size()) {
-    tmp_single_cloud_.width = 0;
-    return tmp_single_cloud_;
-  }
-
-  const std::size_t i = static_cast<std::size_t>(idx);
-  const auto & pptr = perceptions_[i];
-  const auto & idx_list = indices_[i].indices;
-
-  if (!pptr || !pptr->valid || pptr->data.empty() || idx_list.empty()) {
-    tmp_single_cloud_.width = 0;
-    return tmp_single_cloud_;
-  }
-
-  const auto & cloud = pptr->data;
-
-  const bool has_tf = has_target_frame_ &&
-    tf_valid_.size() == perceptions_.size() &&
-    tf_valid_[i];
-
-  for (int id : idx_list) {
-    if (id < 0 || static_cast<std::size_t>(id) >= cloud.size()) {
-      continue;
-    }
-
-    const auto & src = cloud[id];
-    tf2::Vector3 p(src.x, src.y, src.z);
-
-    if (has_tf) {
-      p = tf_transforms_[i] * p;
-    }
-
-    pcl::PointXYZ dst(
-      static_cast<float>(p.x()),
-      static_cast<float>(p.y()),
-      static_cast<float>(p.z()));
-
-    if (collapse_x_) {dst.x = collapse_val_x_;}
-    if (collapse_y_) {dst.y = collapse_val_y_;}
-    if (collapse_z_) {dst.z = collapse_val_z_;}
-
-    tmp_single_cloud_.points.push_back(dst);
-  }
-
-  tmp_single_cloud_.width =
-    static_cast<uint32_t>(tmp_single_cloud_.points.size());
-  return tmp_single_cloud_;
-}
-
-
 PointPerceptionsOpsView &
 PointPerceptionsOpsView::fuse(const std::string & target_frame, bool exact_time)
 {


### PR DESCRIPTION
Hi,

These are the last bugs found in this round:

- **`CircularBuffer::latest_ref()`**: deleted (along with its only caller, `PointPerception::get_last_perception()`) instead of patched — same unsynchronized-reference race as a previous fixed bug, plus no empty-buffer check; `latest()` already provides the same thing safely, and neither had any real caller.
- **`Singleton::removeInstance()`**: replaced `std::once_flag`/`call_once` with a `std::mutex` guarding `getInstance()`/`removeInstance()`, closing a real internal race (concurrent flag reassignment + non-atomic reset). Documented the residual, unfixable-by-locking caveat: a raw `C*` handed out earlier can't be protected from a concurrent `removeInstance()` destroying it.
- **`PointPerceptionsOpsView::as_points(int idx)`**: deleted (along with the `tmp_single_cloud_` scratch buffer) instead of patched — same-thread aliasing hazard between sequential calls, zero callers anywhere (all call sites use the safe by-value `as_points()`).

I want to make clear that none of the bugs detected and fixed today had a real impact. They are potential hazard, but they had not produce serious problems.